### PR TITLE
Fix bug where inbound packets are sent to the onSentPacket event instead of the onRecievedPacket event.

### DIFF
--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/NetworkManager.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/NetworkManager.java
@@ -70,6 +70,7 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet> {
             return this.a();
         }
     };
+
     private final EnumProtocolDirection h;
     private final Queue<NetworkManager.QueuedPacket> i = Queues.newConcurrentLinkedQueue();
     private final ReentrantReadWriteLock j = new ReentrantReadWriteLock();
@@ -187,7 +188,7 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet> {
                 try {
                     for (dev.cobblesword.nachospigot.protocol.PacketListener packetListener : Nacho.get().getPacketListeners())
                     {
-                        if(!packetListener.onSentPacket((PlayerConnection) this.m, packet))
+                        if(!packetListener.onReceivedPacket((PlayerConnection) this.m, packet))
                             return;
                     }
                 } catch (Exception e) {
@@ -201,7 +202,6 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet> {
                 ;
             }
         }
-
     }
 
     public void a(PacketListener packetlistener) {


### PR DESCRIPTION
Not sure if the original behavior is the intended behavior, from my understanding `#channelRead0` receives packets, and in the method call that it calls, we were sending the packets received to the `onSentPacket` event instead of the `onReceivedPacket ` event.