### PR TITLE
Java 16

### DIFF
--- a/NachoSpigot-Server/pom.xml
+++ b/NachoSpigot-Server/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.10</version>
+            <version>3.12.0</version>
         </dependency>
 
         <dependency>

--- a/NachoSpigot-Server/src/main/java/org/bukkit/craftbukkit/Main.java
+++ b/NachoSpigot-Server/src/main/java/org/bukkit/craftbukkit/Main.java
@@ -11,6 +11,7 @@ import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 import net.minecraft.server.MinecraftServer;
 
+import org.apache.commons.lang3.JavaVersion;
 import org.apache.commons.lang3.SystemUtils;
 import org.fusesource.jansi.AnsiConsole;
 
@@ -32,7 +33,7 @@ public class Main {
 //            System.exit(1);
 //        }
         try {
-            if(!SystemUtils.IS_JAVA_15) {
+            if(!SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_15)) {
                 System.err.println("It seems like you are not using Java 15!");
                 System.out.println("The use of Java 15 is strongly recommended.");
             }


### PR DESCRIPTION
There is a warning printed to log when running the server using java 16 even though it's fully compatible.
I'm running this for some hours in production now and haven't seen any issues.