### PR TITLE
Revert commit 08eb620bd73fc1aa537ccacfae1ed19bbddbf7da

### DIFF
--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/MinecraftServer.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/MinecraftServer.java
@@ -876,7 +876,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
             if(this.getPlayerList().getPlayerCount() != 0) // Tuinity
             {
                 // Tuinity start - controlled flush for entity tracker packets
-                java.util.Set<NetworkManager> disabledFlushes = new java.util.HashSet<>(this.getPlayerList().getPlayerCount());
+                List<NetworkManager> disabledFlushes = new java.util.ArrayList<>(this.getPlayerList().getPlayerCount());
                 for (EntityPlayer player : this.getPlayerList().players) {
                     PlayerConnection connection = player.playerConnection;
                     if (connection != null) {


### PR DESCRIPTION
There's no purpose for using a Set here. The "players" collection shouldn't contain duplicates, and no where in the code do we use "disabledFlushes" in a context that would benefit from HashSet. The ArrayList is both faster in this scenario, and makes more sense.