### PR TITLE
Prevent most NBT related overflow exploits (Book/ect) through simple …

### DIFF
--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/PacketDataSerializer.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/PacketDataSerializer.java
@@ -184,7 +184,7 @@ public class PacketDataSerializer extends ByteBuf {
         } else {
             this.readerIndex(i);
             try {
-                return NBTCompressedStreamTools.a((DataInput) (new ByteBufInputStream(this)), new NBTReadLimiter(2097152L));
+                return NBTCompressedStreamTools.a((DataInput) (new ByteBufInputStream(this)), new NBTReadLimiter(50000L));
             } catch (IOException ioexception) {
                 throw new EncoderException(ioexception);
             }


### PR DESCRIPTION
…means

For whatever reason, everyone always implements hacky checks to detect NBT overflow exploits. It's pointless, and makes you look like a fool. This default number, 2097152L, puts an INSANE ~2MB limit on NBT which shouldn't ever be possible unless your server has HUGE books. This commit changes that limit to ~0.05MB in the most efficient way possible. If the cap is hit during reading, a RuntimeException is thrown and the connection is immediately closed. 

Usually I put this at 10,000, but for the sake of others I've increased it to 50,000. It would be wise to make this configurable as I'm sure some servers may use very very large items, or books. For the majority of server types however, this highly reduced limit should be perfect.

I would still advise there to be strict limits put on incoming packets. Usually I limit packets to 1k per second to account for lag since the timeout time is 30 seconds hardcoded. But that's for another commit.