### PR TITLE
FlamePaper-0117 Pearl through blocks

### DIFF
--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/EntityEnderPearl.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/EntityEnderPearl.java
@@ -3,8 +3,11 @@ package net.minecraft.server;
 // CraftBukkit start
 import dev.cobblesword.nachospigot.commons.Constants;
 import org.bukkit.Bukkit;
+import org.github.paperspigot.PaperSpigotConfig;
+import net.minecraft.server.BlockPosition;
 import org.bukkit.craftbukkit.event.CraftEventFactory;
 import org.bukkit.event.player.PlayerTeleportEvent;
+
 // CraftBukkit end
 
 public class EntityEnderPearl extends EntityProjectile {
@@ -38,6 +41,23 @@ public class EntityEnderPearl extends EntityProjectile {
             this.die();
         }
         // PaperSpigot end
+
+        // FlamePaper start - 0117-Pearl-through-blocks
+        BlockPosition blockPosition = movingobjectposition.a();
+        
+        if (blockPosition != null) {
+            IBlockData blockData = world.getType(blockPosition);
+            Block block = blockData.getBlock();
+            boolean collides = 
+                PaperSpigotConfig.pearlPassthroughTripwire && block == Blocks.TRIPWIRE
+                || PaperSpigotConfig.pearlPassthroughFenceGate && (block == Blocks.FENCE_GATE || block == Blocks.SPRUCE_FENCE_GATE || block == Blocks.BIRCH_FENCE_GATE || block == Blocks.JUNGLE_FENCE_GATE || block == Blocks.DARK_OAK_FENCE_GATE || block == Blocks.ACACIA_FENCE_GATE) && ((Boolean) blockData.get(BlockFenceGate.OPEN)).booleanValue()
+                || PaperSpigotConfig.pearlPassthroughSlab && (block == Blocks.STONE_SLAB || block == Blocks.WOODEN_SLAB || block == Blocks.STONE_SLAB2);
+        
+            if (collides) {
+                return;
+            }
+        }
+        // FlamePaper end
 
         for (int i = 0; i < 32; ++i) {
             this.world.addParticle(EnumParticle.PORTAL, this.locX, this.locY + this.random.nextDouble() * 2.0D, this.locZ, this.random.nextGaussian(), 0.0D, this.random.nextGaussian(), Constants.EMPTY_ARRAY);

--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/EntityEnderPearl.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/EntityEnderPearl.java
@@ -50,6 +50,8 @@ public class EntityEnderPearl extends EntityProjectile {
             Block block = blockData.getBlock();
             boolean collides = 
                 PaperSpigotConfig.pearlPassthroughTripwire && block == Blocks.TRIPWIRE
+                || PaperSpigotConfig.pearlPassthroughCobweb && block == Blocks.WEB
+                || PaperSpigotConfig.pearlPassthroughBed && block == Blocks.BED
                 || PaperSpigotConfig.pearlPassthroughFenceGate && (block == Blocks.FENCE_GATE || block == Blocks.SPRUCE_FENCE_GATE || block == Blocks.BIRCH_FENCE_GATE || block == Blocks.JUNGLE_FENCE_GATE || block == Blocks.DARK_OAK_FENCE_GATE || block == Blocks.ACACIA_FENCE_GATE) && ((Boolean) blockData.get(BlockFenceGate.OPEN)).booleanValue()
                 || PaperSpigotConfig.pearlPassthroughSlab && (block == Blocks.STONE_SLAB || block == Blocks.WOODEN_SLAB || block == Blocks.STONE_SLAB2);
         

--- a/NachoSpigot-Server/src/main/java/org/github/paperspigot/PaperSpigotConfig.java
+++ b/NachoSpigot-Server/src/main/java/org/github/paperspigot/PaperSpigotConfig.java
@@ -222,4 +222,24 @@ public class PaperSpigotConfig
     {
         warnForExcessiveVelocity = getBoolean("warnWhenSettingExcessiveVelocity", true);
     }
+
+    // FlamePaper start - 0117-Pearl-through-blocks    
+    public static boolean pearlPassthroughFenceGate;
+    private static void pearlPassthroughFenceGate()
+    {
+        pearlPassthroughFenceGate = getBoolean( "pearl-passthrough.fence_gate", true );
+    }
+    
+    public static boolean pearlPassthroughTripwire;
+    private static void pearlPassthroughTripwire()
+    {
+        pearlPassthroughTripwire = getBoolean( "pearl-passthrough.tripwire", true );
+    }
+    
+    public static boolean pearlPassthroughSlab;
+    private static void pearlPassthroughSlab()
+    {
+        pearlPassthroughSlab = getBoolean( "pearl-passthrough.slab", true );
+    }
+    // FlamePaper end
 }

--- a/NachoSpigot-Server/src/main/java/org/github/paperspigot/PaperSpigotConfig.java
+++ b/NachoSpigot-Server/src/main/java/org/github/paperspigot/PaperSpigotConfig.java
@@ -241,5 +241,17 @@ public class PaperSpigotConfig
     {
         pearlPassthroughSlab = getBoolean( "pearl-passthrough.slab", true );
     }
+
+    public static boolean pearlPassthroughCobweb;
+    private static void pearlPassthroughCobweb()
+    {
+        pearlPassthroughSlab = getBoolean( "pearl-passthrough.cobweb", true );
+    }
+
+    public static boolean pearlPassthroughBed;
+    private static void pearlPassthroughBed()
+    {
+        pearlPassthroughSlab = getBoolean( "pearl-passthrough.bed", false );
+    }
     // FlamePaper end
 }

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ If you find any bugs, please create an issue or contact us in the [Discord serve
 [FlamePaper-0104] Return last slot by default
 [FlamePaper-0105] Fix memory leaks by Minetick
 [FlamePaper-0115] Patch Book Exploits
+[FlamePaper-0117] Pearl through blocks
 
 [MineTick-0006] Fix Occasional Client Side Unloading of Chunk 0 0
 [MineTick-0017] Fix Insane Nether Portal Lag


### PR DESCRIPTION
Original Patch: https://github.com/2lstudios-mc/FlamePaper/blob/ver/1.8.8/Spigot-Server-Patches/0117-Pearl-through-blocks.patch

This patch add options to accept enderpearl bypass fence gates and tripwires.
The only change of this backport to the original is the complete fence gate list, coweb and bed block(s), which is not present on the flamepaper patch.