### PR TITLE
New Configs for optional performance gain

### DIFF
--- a/NachoSpigot-Server/src/main/java/dev/cobblesword/nachospigot/NachoConfig.java
+++ b/NachoSpigot-Server/src/main/java/dev/cobblesword/nachospigot/NachoConfig.java
@@ -16,4 +16,19 @@ public class NachoConfig {
     public int playerTimeStatisticsInterval = 20;
     public String serverBrandName = "NachoSpigot";
     public boolean enableAntiCrash = true;
+    public boolean infiniteWaterSources = true;
+    public boolean leavesDecayEvent = true;
+    public boolean enableMobAI = true;
+    public boolean enableMobSound = true;
+    public boolean enableEntityActivation = true;
+    public boolean enableLavaToCobblestone = true;
+    public boolean firePlayerMoveEvent = true; // Higly recommend disable this for lobby/limbo/minigames servers.
+    public boolean endermiteSpawning = true;
+    public boolean disablePhysicsPlace = false;
+    public boolean disablePhysicsUpdate = false;
+    public boolean doBlocksOperations = true;
+    public boolean doChunkUnload = true;
+    public int chunkThreads = 2; // PaperSpigot - Bumped value
+    public int playersPerThread = 50;
+    public boolean enableTCPNODELAY = true;
 }

--- a/NachoSpigot-Server/src/main/java/dev/cobblesword/nachospigot/protocol/MinecraftPipeline.java
+++ b/NachoSpigot-Server/src/main/java/dev/cobblesword/nachospigot/protocol/MinecraftPipeline.java
@@ -7,6 +7,7 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.timeout.ReadTimeoutHandler;
 import net.minecraft.server.*;
+import dev.cobblesword.nachospigot.Nacho;
 
 public class MinecraftPipeline extends ChannelInitializer<SocketChannel>
 {
@@ -20,7 +21,7 @@ public class MinecraftPipeline extends ChannelInitializer<SocketChannel>
     protected void initChannel(SocketChannel channel) throws Exception
     {
         try {
-            channel.config().setOption(ChannelOption.TCP_NODELAY, true);
+            channel.config().setOption(ChannelOption.TCP_NODELAY, Nacho.get().getConfig().enableTCPNODELAY);
         } catch (ChannelException channelexception) {
             // Ignore
         }

--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/BlockFalling.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/BlockFalling.java
@@ -2,6 +2,7 @@ package net.minecraft.server;
 
 import java.util.Random;
 
+import dev.cobblesword.nachospigot.Nacho;
 public class BlockFalling extends Block {
 
     public static boolean instaFall;
@@ -16,11 +17,15 @@ public class BlockFalling extends Block {
     }
 
     public void onPlace(World world, BlockPosition blockposition, IBlockData iblockdata) {
-        world.a(blockposition, (Block) this, this.a(world));
+        if (!Nacho.get().getConfig().disablePhysicsPlace) {
+            world.a(blockposition, (Block) this, this.a(world));
+        }
     }
 
     public void doPhysics(World world, BlockPosition blockposition, IBlockData iblockdata, Block block) {
-        world.a(blockposition, (Block) this, this.a(world));
+        if (!Nacho.get().getConfig().disablePhysicsUpdate) {
+            world.a(blockposition, (Block) this, this.a(world));
+        }
     }
 
     public void b(World world, BlockPosition blockposition, IBlockData iblockdata, Random random) {

--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/BlockFlowing.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/BlockFlowing.java
@@ -5,6 +5,8 @@ import java.util.Iterator;
 import java.util.Random;
 import java.util.Set;
 
+import dev.cobblesword.nachospigot.Nacho;
+
 // CraftBukkit start
 import org.bukkit.block.BlockFace;
 import org.bukkit.event.block.BlockFromToEvent;
@@ -64,7 +66,7 @@ public class BlockFlowing extends BlockFluids {
                 }
             }
 
-            if (this.a >= 2 && this.material == Material.WATER) {
+            if ((Nacho.get().getConfig().infiniteWaterSources) && (this.a >= 2) && (this.material == Material.WATER)) {
                 IBlockData iblockdata1 = world.getType(blockposition.down());
 
                 if (iblockdata1.getBlock().getMaterial().isBuildable()) {
@@ -112,7 +114,7 @@ public class BlockFlowing extends BlockFluids {
                 server.getPluginManager().callEvent(event);
             }
             if (!event.isCancelled()) {
-            if (this.material == Material.LAVA && world.getType(blockposition.down()).getBlock().getMaterial() == Material.WATER) {
+            if ((this.material == Material.LAVA) && (world.getType(blockposition.down()).getBlock().getMaterial() == Material.WATER) && (Nacho.get().getConfig().enableLavaToCobblestone)) {
                 world.setTypeUpdate(blockposition.down(), Blocks.STONE.getBlockData());
                 this.fizz(world, blockposition.down());
                 return;

--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/BlockFluids.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/BlockFluids.java
@@ -2,6 +2,8 @@ package net.minecraft.server;
 
 import dev.cobblesword.nachospigot.commons.Constants;
 
+import dev.cobblesword.nachospigot.Nacho;
+
 import java.util.Iterator;
 import java.util.Random;
 
@@ -147,7 +149,7 @@ public abstract class BlockFluids extends Block {
                 }
             }
 
-            if (flag) {
+            if ((flag) && (Nacho.get().getConfig().enableLavaToCobblestone)) {
                 Integer integer = (Integer) iblockdata.get(BlockFluids.LEVEL);
 
                 if (integer.intValue() == 0) {

--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/BlockLeaves.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/BlockLeaves.java
@@ -2,6 +2,8 @@ package net.minecraft.server;
 
 import java.util.Random;
 
+import dev.cobblesword.nachospigot.Nacho;
+
 import org.bukkit.event.block.LeavesDecayEvent; // CraftBukkit
 
 public abstract class BlockLeaves extends BlockTransparent {
@@ -132,6 +134,10 @@ public abstract class BlockLeaves extends BlockTransparent {
     }
 
     private void e(World world, BlockPosition blockposition) {
+        if (!Nacho.get().getConfig().leavesDecayEvent) {
+            return;
+        }
+
         // CraftBukkit start
         LeavesDecayEvent event = new LeavesDecayEvent(world.getWorld().getBlockAt(blockposition.getX(), blockposition.getY(), blockposition.getZ()));
         world.getServer().getPluginManager().callEvent(event);

--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/ChunkProviderServer.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/ChunkProviderServer.java
@@ -20,7 +20,7 @@ import it.unimi.dsi.fastutil.longs.LongArraySet;
 import it.unimi.dsi.fastutil.longs.LongIterator;
 import it.unimi.dsi.fastutil.longs.LongSet;
 // TacoSpigot end
-
+import dev.cobblesword.nachospigot.Nacho;
 public class ChunkProviderServer implements IChunkProvider {
 
     private static final Logger b = LogManager.getLogger();
@@ -52,6 +52,10 @@ public class ChunkProviderServer implements IChunkProvider {
     }
 
     public void queueUnload(int i, int j) {
+        if (!Nacho.get().getConfig().doChunkUnload) {
+            return;
+        }
+
         // PaperSpigot start - Asynchronous lighting updates
         Chunk chunk = chunks.get(LongHash.toLong(i, j));
         if (chunk != null && chunk.world.paperSpigotConfig.useAsyncLighting && (chunk.pendingLightUpdates.get() > 0 || chunk.world.getTime() - chunk.lightUpdateTime < 20)) {

--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/EntityEnderPearl.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/EntityEnderPearl.java
@@ -8,6 +8,8 @@ import net.minecraft.server.BlockPosition;
 import org.bukkit.craftbukkit.event.CraftEventFactory;
 import org.bukkit.event.player.PlayerTeleportEvent;
 
+import dev.cobblesword.nachospigot.Nacho;
+
 // CraftBukkit end
 
 public class EntityEnderPearl extends EntityProjectile {
@@ -78,7 +80,7 @@ public class EntityEnderPearl extends EntityProjectile {
                     Bukkit.getPluginManager().callEvent(teleEvent);
 
                     if (!teleEvent.isCancelled() && !entityplayer.playerConnection.isDisconnected()) {
-                        if (this.random.nextFloat() < 0.05F && this.world.getGameRules().getBoolean("doMobSpawning")) {
+                        if ((this.random.nextFloat() < 0.05F) && (this.world.getGameRules().getBoolean("doMobSpawning")) && (Nacho.get().getConfig().endermiteSpawning)) {
                             EntityEndermite entityendermite = new EntityEndermite(this.world);
 
                             entityendermite.a(true);

--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/EntityInsentient.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/EntityInsentient.java
@@ -13,6 +13,7 @@ import org.bukkit.event.entity.EntityTargetEvent;
 import org.bukkit.event.entity.EntityUnleashEvent;
 import org.bukkit.event.entity.EntityUnleashEvent.UnleashReason;
 // CraftBukkit end
+import dev.cobblesword.nachospigot.Nacho;
 
 public abstract class EntityInsentient extends EntityLiving {
 
@@ -163,7 +164,7 @@ public abstract class EntityInsentient extends EntityLiving {
     public void x() {
         String s = this.z();
 
-        if (s != null) {
+        if ((s != null) && (Nacho.get().getConfig().enableMobSound)) {
             this.makeSound(s, this.bB(), this.bC());
         }
 
@@ -493,30 +494,32 @@ public abstract class EntityInsentient extends EntityLiving {
             return;
         }
         // Spigot End
-        this.world.methodProfiler.a("sensing");
-        this.bk.a();
-        this.world.methodProfiler.b();
-        this.world.methodProfiler.a("targetSelector");
-        this.targetSelector.a();
-        this.world.methodProfiler.b();
-        this.world.methodProfiler.a("goalSelector");
-        this.goalSelector.a();
-        this.world.methodProfiler.b();
-        this.world.methodProfiler.a("navigation");
-        this.navigation.k();
-        this.world.methodProfiler.b();
-        this.world.methodProfiler.a("mob tick");
-        this.E();
-        this.world.methodProfiler.b();
-        this.world.methodProfiler.a("controls");
-        this.world.methodProfiler.a("move");
-        this.moveController.c();
-        this.world.methodProfiler.c("look");
-        this.lookController.a();
-        this.world.methodProfiler.c("jump");
-        this.g.b();
-        this.world.methodProfiler.b();
-        this.world.methodProfiler.b();
+        if (Nacho.get().getConfig().enableMobAI) {
+            this.world.methodProfiler.a("sensing");
+            this.bk.a();
+            this.world.methodProfiler.b();
+            this.world.methodProfiler.a("targetSelector");
+            this.targetSelector.a();
+            this.world.methodProfiler.b();
+            this.world.methodProfiler.a("goalSelector");
+            this.goalSelector.a();
+            this.world.methodProfiler.b();
+            this.world.methodProfiler.a("navigation");
+            this.navigation.k();
+            this.world.methodProfiler.b();
+            this.world.methodProfiler.a("mob tick");
+            this.E();
+            this.world.methodProfiler.b();
+            this.world.methodProfiler.a("controls");
+            this.world.methodProfiler.a("move");
+            this.moveController.c();
+            this.world.methodProfiler.c("look");
+            this.lookController.a();
+            this.world.methodProfiler.c("jump");
+            this.g.b();
+            this.world.methodProfiler.b();
+            this.world.methodProfiler.b();
+        }
     }
 
     protected void E() {}

--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/PlayerConnection.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/PlayerConnection.java
@@ -364,7 +364,7 @@ public class PlayerConnection implements PacketListenerPlayIn, IUpdatePlayerList
                     this.lastPitch = to.getPitch();
 
                     // Skip the first time we do this
-                    if (true) { // Spigot - don't skip any move events
+                    if (Nacho.get().getConfig().firePlayerMoveEvent) { // Spigot - don't skip any move events
                         Location oldTo = to.clone();
                         PlayerMoveEvent event = new PlayerMoveEvent(player, from, to);
                         this.server.getPluginManager().callEvent(event);

--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/World.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/World.java
@@ -21,6 +21,8 @@ import co.aikar.timings.SpigotTimings;
 import java.util.*;
 import java.util.concurrent.Callable;
 
+import dev.cobblesword.nachospigot.Nacho;
+
 // PaperSpigot start
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -1836,7 +1838,7 @@ public abstract class World implements IBlockAccess {
         byte b0 = 32;
 
         // Spigot start
-        if (!org.spigotmc.ActivationRange.checkIfActive(entity)) {
+        if ((!org.spigotmc.ActivationRange.checkIfActive(entity)) && (Nacho.get().getConfig().enableEntityActivation)) {
             entity.ticksLived++;
             entity.inactiveTick();
             // PaperSpigot start - Remove entities in unloaded chunks

--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/WorldServer.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/WorldServer.java
@@ -28,6 +28,7 @@ import org.bukkit.craftbukkit.util.HashTreeSet;
 import org.bukkit.event.block.BlockFormEvent;
 import org.bukkit.event.weather.LightningStrikeEvent;
 // CraftBukkit end
+import dev.cobblesword.nachospigot.Nacho;
 
 public class WorldServer extends World implements IAsyncTaskHandler {
 
@@ -229,12 +230,14 @@ public class WorldServer extends World implements IAsyncTaskHandler {
             // CraftBukkit end
         }
         // CraftBukkit end
-        timings.doChunkUnload.startTiming(); // Spigot
-        this.methodProfiler.c("chunkSource");
+        if (Nacho.get().getConfig().doChunkUnload) {
+            timings.doChunkUnload.startTiming(); // Spigot
+            this.methodProfiler.c("chunkSource");
 
-        // Only unload if chunkProvider isn't null
-        if (this.chunkProvider != null) {
-            this.chunkProvider.unloadChunks();
+            // Only unload if chunkProvider isn't null
+            if (this.chunkProvider != null) {
+                this.chunkProvider.unloadChunks();
+            }
         }
 
         int j = this.a(1.0F);
@@ -474,26 +477,28 @@ public class WorldServer extends World implements IAsyncTaskHandler {
                     }
                 }
 
-                this.methodProfiler.c("tickBlocks");
-                timings.chunkTicksBlocks.startTiming(); // Spigot
-                int randomTickSpeed = this.getGameRules().c("randomTickSpeed");
-                if (randomTickSpeed > 0) {
-                    for (ChunkSection section : chunk.getSections()) {
-                        if (section != null && section.shouldTick()) {
-                            for (int l1 = 0; l1 < randomTickSpeed; ++l1) {
-                                this.m = this.m * 3 + 1013904223;
-                                int i2 = this.m >> 2;
-                                int j2 = i2 & 15;
-                                int k2 = i2 >> 8 & 15;
-                                int l2 = i2 >> 16 & 15;
+                if (Nacho.get().getConfig().doBlocksOperations) {
+                    this.methodProfiler.c("tickBlocks");
+                    timings.chunkTicksBlocks.startTiming(); // Spigot
+                    int randomTickSpeed = this.getGameRules().c("randomTickSpeed");
+                    if (randomTickSpeed > 0) {
+                        for (ChunkSection section : chunk.getSections()) {
+                            if (section != null && section.shouldTick()) {
+                                for (int l1 = 0; l1 < randomTickSpeed; ++l1) {
+                                    this.m = this.m * 3 + 1013904223;
+                                    int i2 = this.m >> 2;
+                                    int j2 = i2 & 15;
+                                    int k2 = i2 >> 8 & 15;
+                                    int l2 = i2 >> 16 & 15;
 
-                                ++j;
-                                IBlockData iblockdata = section.getType(j2, l2, k2);
-                                Block block = iblockdata.getBlock();
+                                    ++j;
+                                    IBlockData iblockdata = section.getType(j2, l2, k2);
+                                    Block block = iblockdata.getBlock();
 
-                                if (block.isTicking()) {
-                                    ++i;
-                                    block.a(this, new BlockPosition(j2 + k, l2 + section.getYPosition(), k2 + l), iblockdata, this.random);
+                                    if (block.isTicking()) {
+                                        ++i;
+                                        block.a(this, new BlockPosition(j2 + k, l2 + section.getYPosition(), k2 + l), iblockdata, this.random);
+                                    }
                                 }
                             }
                         }

--- a/NachoSpigot-Server/src/main/java/org/bukkit/craftbukkit/chunkio/ChunkIOExecutor.java
+++ b/NachoSpigot-Server/src/main/java/org/bukkit/craftbukkit/chunkio/ChunkIOExecutor.java
@@ -5,10 +5,11 @@ import net.minecraft.server.ChunkProviderServer;
 import net.minecraft.server.ChunkRegionLoader;
 import net.minecraft.server.World;
 import org.bukkit.craftbukkit.util.AsynchronousExecutor;
+import dev.cobblesword.nachospigot.Nacho;
 
 public class ChunkIOExecutor {
-    static final int BASE_THREADS = 2; // PaperSpigot - Bumped value
-    static final int PLAYERS_PER_THREAD = 50;
+    static final int BASE_THREADS = Nacho.get().getConfig().chunkThreads;
+    static final int PLAYERS_PER_THREAD = Nacho.get().getConfig().playersPerThread;
 
     private static final AsynchronousExecutor<QueuedChunk, Chunk, Runnable, RuntimeException> instance = new AsynchronousExecutor<QueuedChunk, Chunk, Runnable, RuntimeException>(new ChunkIOProvider(), BASE_THREADS);
 


### PR DESCRIPTION
Added new configs options for optional performance gain, this is an easy and performatic way to allow custom servers change their configs without plugin throttling, and also, give an option to the servers administrators ajust the configurations under their desire.

About the configurations implemented:
- infiniteWaterSources: control the behavior of infinite water method.
- leavesDecayEvent: control the behavior of leavesDecayEvent event, even before it fires inside the code.
- enableMobAI: controls MobAI
- enableMobSound: controls mobs sounds.
- enableEntityActivation: control the behavior of entity activation.
- enableLavaToCobblestone: control the behavior into transforming lava to cobblestone blocks, and also obsidian.
- firePlayerMoveEvent: control the event PlayerMove, if this config be disabled, the server will not track the player movement, can be helpful for performance, but also, can be dangerous for some plugins implementations.
- endermiteSpawning: control the spawn of endermite after throw an enderpearl.
- disablePhysicsPlace: control the physics behavior of a block after place it (example: sand).
- disablePhysicsUpdate: control the physics behavior of a block after it change/update (example: when you break an sand block in the desert and the blocks fall, if this option be disabled, this will not happen).
- doBlocksOperations: control the operation of blocks on the server (example: the growth of a cane or wheat crop may be stopped if this setting is turned off).
- doChunkUnload: control the behavior of the chunk unload, this can be helpful for lobby/limbo servers.
- chunkThreads: control the amount of threads designed to manage the chunks, if you change this option we recommend you change the netty-threads in spigot.yml (default by paper: 2).
- playersPerThread: control the amount of players designed to be in a thread (default by paper: 50).

On the future i will be implementing custom commands for servers administrators do some of this changes in-game, but only the safe changes without restart.