### PR TITLE
serverName & serverVersion fit config

### DIFF
--- a/NachoSpigot-Server/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+++ b/NachoSpigot-Server/src/main/java/org/bukkit/craftbukkit/CraftServer.java
@@ -129,8 +129,8 @@ import net.md_5.bungee.api.chat.BaseComponent;
 
 public final class CraftServer implements Server {
     private static final Player[] EMPTY_PLAYER_ARRAY = new Player[0];
-    private String serverName = "NachoSpigot";
-    private final String serverVersion = "1.8.8";
+    private String serverName = Nacho.get().getConfig().serverBrandName;
+    private final String serverVersion = Nacho.get().getConfig().serverBrandName + "-1.8.8";
     private final String bukkitVersion = Versioning.getBukkitVersion();
     private final Logger logger = Logger.getLogger("Minecraft");
     private final ServicesManager servicesManager = new SimpleServicesManager();

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Nacho can now be used in production environments.
 
 If you find any bugs, please create an issue or contact us in the [Discord server](https://discord.gg/ewcYeERKJw)!
 
-**NachoSpigot supports Java 8 to Java 15!**
+**NachoSpigot supports Java 8 to Java 16!**
 
 ## Download
 **Stable:** [https://nacho.sculas.xyz/](https://nacho.sculas.xyz/)


### PR DESCRIPTION
https://imgur.com/a/Vvnyakb
It get the serverName from the config. I think its only the first part of "This server is running NachoSpigot version" which will get customized.
It changes the serverVersion that the version don't look like "1.8.8", it look like "NachoSpigot-1.8.8".  Paper 1.17 has for example "git-Paper-114". 
The whole commit should only change the server log message & the timings. It doesnt affect the MOD in F3. If you want that it say everytime NachoSpigot in the log, you can simply change it back :P
Change readme from java 15 to java 16 because it works know, don't know why it got changed. If it's wrong you know what to do.