### PR TITLE
Backport server tick events from Paper

### DIFF
--- a/NachoSpigot-API/src/main/java/com/destroystokyo/paper/event/server/ServerTickEndEvent.java
+++ b/NachoSpigot-API/src/main/java/com/destroystokyo/paper/event/server/ServerTickEndEvent.java
@@ -1,0 +1,56 @@
+package com.destroystokyo.paper.event.server;
+
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Called when the server has finished ticking the main loop
+ */
+public class ServerTickEndEvent extends Event {
+
+    private static final HandlerList handlers = new HandlerList();
+    private final int tickNumber;
+    private final double tickDuration;
+    private final long timeEnd;
+
+    public ServerTickEndEvent(int tickNumber, double tickDuration, long timeRemaining) {
+        this.tickNumber = tickNumber;
+        this.tickDuration = tickDuration;
+        this.timeEnd = System.nanoTime() + timeRemaining;
+    }
+
+    /**
+     * @return What tick this was since start (first tick = 1)
+     */
+    public int getTickNumber() {
+        return tickNumber;
+    }
+
+    /**
+     * @return Time in milliseconds of how long this tick took
+     */
+    public double getTickDuration() {
+        return tickDuration;
+    }
+
+    /**
+     * Amount of nanoseconds remaining before the next tick should start.
+     *
+     * If this value is negative, then that means the server has exceeded the tick time limit and TPS has been lost.
+     *
+     * Method will continously return the updated time remaining value. (return value is not static)
+     *
+     * @return Amount of nanoseconds remaining before the next tick should start
+     */
+    public long getTimeRemaining() {
+        return this.timeEnd - System.nanoTime();
+    }
+
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/NachoSpigot-API/src/main/java/com/destroystokyo/paper/event/server/ServerTickStartEvent.java
+++ b/NachoSpigot-API/src/main/java/com/destroystokyo/paper/event/server/ServerTickStartEvent.java
@@ -1,0 +1,29 @@
+package com.destroystokyo.paper.event.server;
+
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+public class ServerTickStartEvent extends Event {
+
+    private static final HandlerList handlers = new HandlerList();
+    private final int tickNumber;
+
+    public ServerTickStartEvent(int tickNumber) {
+        this.tickNumber = tickNumber;
+    }
+
+    /**
+     * @return What tick this is going be since start (first tick = 1)
+     */
+    public int getTickNumber() {
+        return tickNumber;
+    }
+
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/MinecraftServer.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/MinecraftServer.java
@@ -611,7 +611,13 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
                     }
                     lastTick = curTime;
 
+                    // NachoSpigot start - backport tick events from Paper
+                    this.server.getPluginManager().callEvent(new com.destroystokyo.paper.event.server.ServerTickStartEvent(this.ticks+1));
                     this.A();
+                    long endTime = System.nanoTime();
+                    long remaining = (TICK_TIME - (endTime - lastTick)) - catchupTime;
+                    this.server.getPluginManager().callEvent(new com.destroystokyo.paper.event.server.ServerTickEndEvent(this.ticks, ((double)(endTime - lastTick) / 1000000D), remaining));
+                    // NachoSpigot end
                     this.Q = true;
                 }
                 // Spigot end


### PR DESCRIPTION
This patch was added in the late 1.13.2 era, and is used by plugins such as anti-cheats and performance monitors to tell when a tick has started and ended.

Here is an example of it being used by [spark](https://spark.lucko.me/) to display tick durations. ![Spark showing tick durations in /tps](https://i.hpfxd.com/L8My)