### PR TITLE
Fixing NoSuchMethodError when generating chunks.

### DIFF
--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/MathHelper.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/MathHelper.java
@@ -169,6 +169,10 @@ public class MathHelper {
         }
     }
 
+    public static double a(String var0, double var1, double var3) {
+        return FastMath.max(var3, a(var0, var1));
+    }
+
     public static int b(int var0) {
         int var1 = var0 - 1;
         var1 |= var1 >> 1;


### PR DESCRIPTION
Fixing NoSuchMethodError when a server is generating a new chunk.
This was related due to #183 because NoiseGeneratorOctaves was using the method which was deleted in #183.