### PR TITLE
Downgrade JAnsi version

### DIFF
--- a/NachoSpigot-Server/pom.xml
+++ b/NachoSpigot-Server/pom.xml
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>org.fusesource.jansi</groupId>
             <artifactId>jansi</artifactId>
-            <version>2.4.0</version>
+            <version>1.12</version>
         </dependency>
 
         <!-- testing -->


### PR DESCRIPTION
Use the [same version that JLine2 uses for JANSI](https://github.com/jline/jline2/blob/master/pom.xml#L122)