### PR TITLE
Recode of EnumProtocol & Suppliers

### DIFF
--- a/NachoSpigot-Server/src/main/java/me/elier/nachospigot/config/NachoConfig.java
+++ b/NachoSpigot-Server/src/main/java/me/elier/nachospigot/config/NachoConfig.java
@@ -50,7 +50,7 @@ public class NachoConfig {
         File old_config = new File("nacho.json");
         if(old_config.exists()) migrate(old_config);
 
-        int configVersion = 2; // Update this every new configuration update
+        int configVersion = 3; // Update this every new configuration update
         version = getInt("config-version", configVersion);
         set("config-version", configVersion);
         c.setHeader(HEADER);
@@ -154,7 +154,7 @@ public class NachoConfig {
 
     private static <T> List getList(String path, T def) {
         config.addDefault(path, def);
-        return (List<T>) config.getList(path, config.getList(path));
+        return config.getList(path, config.getList(path));
     }
 
     private static String getString(String path, String def) {
@@ -320,6 +320,13 @@ public class NachoConfig {
     private static void disableFallAnimation() {
         disabledFallBlockAnimation = getBoolean("settings.disabled-block-fall-animation", false);
         c.addComment("settings.disabled-block-fall-animation", "Disables the fall animation for blocks");
+    }
+
+    public static boolean enableProtocolLibShim;
+
+    private static void enableProtocolLibShim() {
+        enableProtocolLibShim = getBoolean("settings.enable-protocollib-shim", true);
+        c.addComment("settings.enable-protocollib-shim", "Enable ProtocolLib network shim. Allows ProtocolLib to work, but requires extra memory. Disable this if you don't use ProtocolLib!");
     }
 
 }

--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/ChunkProviderServer.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/ChunkProviderServer.java
@@ -408,7 +408,7 @@ public class ChunkProviderServer implements IChunkProvider {
         // TacoSpigot start - use iterator for unloadQueue
         LongIterator iterator = unloadQueue.iterator();
         for (int i = 0; i < 100 && iterator.hasNext(); ++i) {
-            long chunkcoordinates = iterator.next();
+            long chunkcoordinates = iterator.nextLong();
             iterator.remove();
             // TacoSpigot end
             Chunk chunk = this.chunks.get(chunkcoordinates);

--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/EnumProtocol.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/EnumProtocol.java
@@ -146,7 +146,7 @@ public enum EnumProtocol {
     private static Map<Class<? extends Packet<?>>, EnumProtocol> packetClass2State = Maps.newHashMap();
 
     private final Object2IntMap<Class<? extends Packet<?>>> packetClassToId = new Object2IntOpenHashMap<>(16, 0.5f);
-    private final Map<EnumProtocolDirection, IntObjectMap<Supplier<Packet<?>>>> packetMap = new HashMap<>();
+    private final Map<EnumProtocolDirection, IntObjectMap<Supplier<Packet<?>>>> packetMap = Maps.newEnumMap(EnumProtocolDirection.class);
 
     private final int stateId;
 

--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/EnumProtocol.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/EnumProtocol.java
@@ -1,175 +1,189 @@
 package net.minecraft.server;
 
-import com.google.common.collect.BiMap;
-import com.google.common.collect.HashBiMap;
 import com.google.common.collect.Maps;
-import java.util.Iterator;
+
+import java.util.HashMap;
 import java.util.Map;
-import org.apache.logging.log4j.LogManager;
+import java.util.function.Supplier;
+
+import io.netty.util.collection.IntObjectHashMap;
+import io.netty.util.collection.IntObjectMap;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 
 public enum EnumProtocol {
 
     HANDSHAKING(-1) {
         {
-            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketHandshakingInSetProtocol.class);
+            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketHandshakingInSetProtocol.class, PacketHandshakingInSetProtocol::new);
         }
     }, PLAY(0) {
         {
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutKeepAlive.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutLogin.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutChat.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutUpdateTime.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutEntityEquipment.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutSpawnPosition.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutUpdateHealth.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutRespawn.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutPosition.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutHeldItemSlot.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutBed.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutAnimation.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutNamedEntitySpawn.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutCollect.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutSpawnEntity.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutSpawnEntityLiving.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutSpawnEntityPainting.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutSpawnEntityExperienceOrb.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutEntityVelocity.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutEntityDestroy.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutEntity.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutEntity.PacketPlayOutRelEntityMove.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutEntity.PacketPlayOutEntityLook.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutEntityTeleport.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutEntityHeadRotation.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutEntityStatus.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutAttachEntity.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutEntityMetadata.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutEntityEffect.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutRemoveEntityEffect.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutExperience.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutUpdateAttributes.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutMapChunk.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutMultiBlockChange.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutBlockChange.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutBlockAction.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutBlockBreakAnimation.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutMapChunkBulk.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutExplosion.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutWorldEvent.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutNamedSoundEffect.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutWorldParticles.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutGameStateChange.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutSpawnEntityWeather.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutOpenWindow.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutCloseWindow.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutSetSlot.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutWindowItems.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutWindowData.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutTransaction.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutUpdateSign.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutMap.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutTileEntityData.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutOpenSignEditor.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutStatistic.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutPlayerInfo.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutAbilities.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutTabComplete.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutScoreboardObjective.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutScoreboardScore.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutScoreboardDisplayObjective.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutScoreboardTeam.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutCustomPayload.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutKickDisconnect.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutServerDifficulty.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutCombatEvent.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutCamera.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutWorldBorder.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutTitle.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutSetCompression.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutPlayerListHeaderFooter.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutResourcePackSend.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutUpdateEntityNBT.class);
-            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInKeepAlive.class);
-            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInChat.class);
-            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInUseEntity.class);
-            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInFlying.class);
-            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInFlying.PacketPlayInPosition.class);
-            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInFlying.PacketPlayInLook.class);
-            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInFlying.PacketPlayInPositionLook.class);
-            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInBlockDig.class);
-            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInBlockPlace.class);
-            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInHeldItemSlot.class);
-            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInArmAnimation.class);
-            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInEntityAction.class);
-            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInSteerVehicle.class);
-            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInCloseWindow.class);
-            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInWindowClick.class);
-            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInTransaction.class);
-            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInSetCreativeSlot.class);
-            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInEnchantItem.class);
-            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInUpdateSign.class);
-            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInAbilities.class);
-            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInTabComplete.class);
-            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInSettings.class);
-            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInClientCommand.class);
-            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInCustomPayload.class);
-            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInSpectate.class);
-            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInResourcePackStatus.class);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutKeepAlive.class, PacketPlayOutKeepAlive::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutLogin.class, PacketPlayOutLogin::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutChat.class, PacketPlayOutChat::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutUpdateTime.class, PacketPlayOutUpdateTime::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutEntityEquipment.class, PacketPlayOutEntityEquipment::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutSpawnPosition.class, PacketPlayOutSpawnPosition::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutUpdateHealth.class, PacketPlayOutUpdateHealth::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutRespawn.class, PacketPlayOutRespawn::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutPosition.class, PacketPlayOutPosition::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutHeldItemSlot.class, PacketPlayOutHeldItemSlot::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutBed.class, PacketPlayOutBed::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutAnimation.class, PacketPlayOutAnimation::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutNamedEntitySpawn.class, PacketPlayOutNamedEntitySpawn::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutCollect.class, PacketPlayOutCollect::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutSpawnEntity.class, PacketPlayOutSpawnEntity::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutSpawnEntityLiving.class, PacketPlayOutSpawnEntityLiving::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutSpawnEntityPainting.class, PacketPlayOutSpawnEntityPainting::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutSpawnEntityExperienceOrb.class, PacketPlayOutSpawnEntityExperienceOrb::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutEntityVelocity.class, PacketPlayOutEntityVelocity::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutEntityDestroy.class, PacketPlayOutEntityDestroy::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutEntity.class, PacketPlayOutEntity::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutEntity.PacketPlayOutRelEntityMove.class, PacketPlayOutEntity.PacketPlayOutRelEntityMove::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutEntity.PacketPlayOutEntityLook.class, PacketPlayOutEntity.PacketPlayOutEntityLook::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook.class, PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutEntityTeleport.class, PacketPlayOutEntityTeleport::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutEntityHeadRotation.class, PacketPlayOutEntityHeadRotation::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutEntityStatus.class, PacketPlayOutEntityStatus::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutAttachEntity.class, PacketPlayOutAttachEntity::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutEntityMetadata.class, PacketPlayOutEntityMetadata::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutEntityEffect.class, PacketPlayOutEntityEffect::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutRemoveEntityEffect.class, PacketPlayOutRemoveEntityEffect::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutExperience.class, PacketPlayOutExperience::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutUpdateAttributes.class, PacketPlayOutUpdateAttributes::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutMapChunk.class, PacketPlayOutMapChunk::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutMultiBlockChange.class, PacketPlayOutMultiBlockChange::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutBlockChange.class, PacketPlayOutBlockChange::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutBlockAction.class, PacketPlayOutBlockAction::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutBlockBreakAnimation.class, PacketPlayOutBlockBreakAnimation::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutMapChunkBulk.class, PacketPlayOutMapChunkBulk::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutExplosion.class, PacketPlayOutExplosion::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutWorldEvent.class, PacketPlayOutWorldEvent::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutNamedSoundEffect.class, PacketPlayOutNamedSoundEffect::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutWorldParticles.class, PacketPlayOutWorldParticles::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutGameStateChange.class, PacketPlayOutGameStateChange::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutSpawnEntityWeather.class, PacketPlayOutSpawnEntityWeather::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutOpenWindow.class, PacketPlayOutOpenWindow::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutCloseWindow.class, PacketPlayOutCloseWindow::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutSetSlot.class, PacketPlayOutSetSlot::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutWindowItems.class, PacketPlayOutWindowItems::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutWindowData.class, PacketPlayOutWindowData::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutTransaction.class, PacketPlayOutTransaction::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutUpdateSign.class, PacketPlayOutUpdateSign::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutMap.class, PacketPlayOutMap::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutTileEntityData.class, PacketPlayOutTileEntityData::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutOpenSignEditor.class, PacketPlayOutOpenSignEditor::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutStatistic.class, PacketPlayOutStatistic::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutPlayerInfo.class, PacketPlayOutPlayerInfo::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutAbilities.class, PacketPlayOutAbilities::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutTabComplete.class, PacketPlayOutTabComplete::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutScoreboardObjective.class, PacketPlayOutScoreboardObjective::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutScoreboardScore.class, PacketPlayOutScoreboardScore::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutScoreboardDisplayObjective.class, PacketPlayOutScoreboardDisplayObjective::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutScoreboardTeam.class, PacketPlayOutScoreboardTeam::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutCustomPayload.class, PacketPlayOutCustomPayload::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutKickDisconnect.class, PacketPlayOutKickDisconnect::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutServerDifficulty.class, PacketPlayOutServerDifficulty::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutCombatEvent.class, PacketPlayOutCombatEvent::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutCamera.class, PacketPlayOutCamera::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutWorldBorder.class, PacketPlayOutWorldBorder::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutTitle.class, PacketPlayOutTitle::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutSetCompression.class, PacketPlayOutSetCompression::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutPlayerListHeaderFooter.class, PacketPlayOutPlayerListHeaderFooter::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutResourcePackSend.class, PacketPlayOutResourcePackSend::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketPlayOutUpdateEntityNBT.class, PacketPlayOutUpdateEntityNBT::new);
+            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInKeepAlive.class, PacketPlayInKeepAlive::new);
+            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInChat.class, PacketPlayInChat::new);
+            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInUseEntity.class, PacketPlayInUseEntity::new);
+            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInFlying.class, PacketPlayInFlying::new);
+            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInFlying.PacketPlayInPosition.class, PacketPlayInFlying.PacketPlayInPosition::new);
+            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInFlying.PacketPlayInLook.class, PacketPlayInFlying.PacketPlayInLook::new);
+            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInFlying.PacketPlayInPositionLook.class, PacketPlayInFlying.PacketPlayInPositionLook::new);
+            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInBlockDig.class, PacketPlayInBlockDig::new);
+            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInBlockPlace.class, PacketPlayInBlockPlace::new);
+            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInHeldItemSlot.class, PacketPlayInHeldItemSlot::new);
+            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInArmAnimation.class, PacketPlayInArmAnimation::new);
+            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInEntityAction.class, PacketPlayInEntityAction::new);
+            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInSteerVehicle.class, PacketPlayInSteerVehicle::new);
+            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInCloseWindow.class, PacketPlayInCloseWindow::new);
+            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInWindowClick.class, PacketPlayInWindowClick::new);
+            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInTransaction.class, PacketPlayInTransaction::new);
+            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInSetCreativeSlot.class, PacketPlayInSetCreativeSlot::new);
+            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInEnchantItem.class, PacketPlayInEnchantItem::new);
+            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInUpdateSign.class, PacketPlayInUpdateSign::new);
+            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInAbilities.class, PacketPlayInAbilities::new);
+            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInTabComplete.class, PacketPlayInTabComplete::new);
+            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInSettings.class, PacketPlayInSettings::new);
+            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInClientCommand.class, PacketPlayInClientCommand::new);
+            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInCustomPayload.class, PacketPlayInCustomPayload::new);
+            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInSpectate.class, PacketPlayInSpectate::new);
+            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketPlayInResourcePackStatus.class, PacketPlayInResourcePackStatus::new);
         }
     }, STATUS(1) {
         {
-            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketStatusInStart.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketStatusOutServerInfo.class);
-            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketStatusInPing.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketStatusOutPong.class);
+            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketStatusInStart.class, PacketStatusInStart::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketStatusOutServerInfo.class, PacketStatusOutServerInfo::new);
+            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketStatusInPing.class, PacketStatusInPing::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketStatusOutPong.class, PacketStatusOutPong::new);
         }
     }, LOGIN(2) {
         {
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketLoginOutDisconnect.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketLoginOutEncryptionBegin.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketLoginOutSuccess.class);
-            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketLoginOutSetCompression.class);
-            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketLoginInStart.class);
-            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketLoginInEncryptionBegin.class);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketLoginOutDisconnect.class, PacketLoginOutDisconnect::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketLoginOutEncryptionBegin.class, PacketLoginOutEncryptionBegin::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketLoginOutSuccess.class, PacketLoginOutSuccess::new);
+            this.registerPacket(EnumProtocolDirection.CLIENTBOUND, PacketLoginOutSetCompression.class, PacketLoginOutSetCompression::new);
+            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketLoginInStart.class, PacketLoginInStart::new);
+            this.registerPacket(EnumProtocolDirection.SERVERBOUND, PacketLoginInEncryptionBegin.class, PacketLoginInEncryptionBegin::new);
         }
     };
 
     private static final int handshakeId = -1;
     private static final int loginId = 2;
 
-    private static final EnumProtocol[] g = new EnumProtocol[loginId - handshakeId + 1]; // 4
-    private static final Map<Class<? extends Packet<?>>, EnumProtocol> protocolMap = Maps.newHashMap();
-    private final int protocolId;
-    private final Map<EnumProtocolDirection, BiMap<Integer, Class<? extends Packet<?>>>> packetMap;
+    private static final EnumProtocol[] STATES = new EnumProtocol[loginId - handshakeId + 1]; // 4
 
-    EnumProtocol(int protocolId) {
-        this.packetMap = Maps.newEnumMap(EnumProtocolDirection.class);
-        this.protocolId = protocolId;
+    private static Map<Class<? extends Packet<?>>, EnumProtocol> packetClass2State = Maps.newHashMap();
+
+    private final Object2IntMap<Class<? extends Packet<?>>> packetClassToId = new Object2IntOpenHashMap<>(16, 0.5f);
+    private final Map<EnumProtocolDirection, IntObjectMap<Supplier<Packet<?>>>> packetMap = new HashMap<>();
+
+    private final int stateId;
+
+    EnumProtocol(int stateId) {
+        this.stateId = stateId;
     }
 
-    protected void registerPacket(EnumProtocolDirection dir, Class<? extends Packet<?>> packet) {
-        BiMap<Integer, Class<? extends Packet<?>>> map = this.packetMap.computeIfAbsent(dir, k -> HashBiMap.create());
+    public int getStateId() {
+        return this.stateId;
+    }
 
-        if (map.containsValue(packet)) {
-            String s = dir + " packet " + packet + " is already known to ID " + map.inverse().get(packet);
-            LogManager.getLogger().fatal(s);
-            throw new IllegalArgumentException(s);
-        } else {
-            map.put(map.size(), packet);
+    protected void registerPacket(EnumProtocolDirection dir, Class<? extends Packet<?>> clazz, Supplier<Packet<?>> packet) {
+        IntObjectMap<Supplier<Packet<?>>> map = this.packetMap.computeIfAbsent(dir, k -> new IntObjectHashMap<>(16, 0.5f));
+        int packetId = map.size(); // think of this as an incrementing integer, well that's what it basically is
+
+        // TODO: Remove this! Something is causing packetClass2State to be null when running tests,
+        //  while I'm pretty sure it sets the variable to Maps.newHashMap on creation. Java is weird.
+        if (packetClass2State == null) {
+            packetClass2State = new HashMap<>();
         }
+
+        EnumProtocol.packetClass2State.put(clazz, this);
+        this.packetClassToId.put(clazz, packetId);
+        map.put(packetId, packet);
     }
 
-    public Integer a(EnumProtocolDirection direction, Packet<?> packet) {
-        return this.packetMap.get(direction).inverse().get(packet.getClass());
+    public Packet<?> createPacket(EnumProtocolDirection direction, int packetId) {
+        Supplier<Packet<?>> packet = this.packetMap.get(direction).get(packetId);
+        return packet == null ? null : packet.get();
     }
 
-    public Packet<?> a(EnumProtocolDirection direction, int i) throws IllegalAccessException, InstantiationException {
-        Class<?> packetClass = (Class<?>) ((BiMap<?, ?>) this.packetMap.get(direction)).get(i);
-        return packetClass == null ? null : (Packet<?>) packetClass.newInstance();
+    public Integer getPacketIdForPacket(Packet<?> packet) {
+        return this.packetClassToId.getInt(packet.getClass());
     }
 
-    public int getProtocolId() {
-        return this.protocolId;
+    public static EnumProtocol getProtocolForPacket(Packet<?> packet) {
+        return packetClass2State.get(packet.getClass());
     }
 
     /**
@@ -177,34 +191,16 @@ public enum EnumProtocol {
      * @return the packets for the intention if valid, else null
      */
     public static EnumProtocol isValidIntention(int protocol) {
-        return protocol >= handshakeId && protocol <= loginId ? g[protocol - handshakeId] : null;
-    }
-
-    public static EnumProtocol getProtocolForPacket(Packet<?> packet) {
-        return protocolMap.get(packet.getClass());
+        return protocol >= handshakeId && protocol <= loginId ? STATES[protocol - handshakeId] : null;
     }
 
     static {
         for (EnumProtocol protocol : values()) {
-            int bound = protocol.getProtocolId();
+            int bound = protocol.getStateId();
             if (bound < handshakeId || bound > loginId) {
                 throw new Error("Invalid protocol ID " + bound);
             }
-            g[bound - handshakeId] = protocol;
-            for (EnumProtocolDirection direction : protocol.packetMap.keySet()) {
-                Class<? extends Packet<?>> packetClass;
-                for (Iterator<Class<? extends Packet<?>>> packets = protocol.packetMap.get(direction).values().iterator(); packets.hasNext(); protocolMap.put(packetClass, protocol)) {
-                    packetClass = packets.next();
-                    if (protocolMap.containsKey(packetClass) && protocolMap.get(packetClass) != protocol) {
-                        throw new Error("Packet " + packetClass + " is already assigned to protocol " + protocolMap.get(packetClass) + " - can't reassign to " + protocol);
-                    }
-                    try {
-                        packetClass.newInstance();
-                    } catch (Throwable throwable) {
-                        throw new Error("Packet " + packetClass + " fails instantiation checks! " + packetClass);
-                    }
-                }
-            }
+            STATES[bound - handshakeId] = protocol;
         }
     }
 }

--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/EnumProtocol.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/EnumProtocol.java
@@ -4,7 +4,6 @@ import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import com.google.common.collect.Maps;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -193,11 +192,11 @@ public enum EnumProtocol {
     }
 
     /**
-     * @param protocol the intention from the packet
+     * @param state the intention from the packet
      * @return the packets for the intention if valid, else null
      */
-    public static EnumProtocol isValidIntention(int protocol) {
-        return protocol >= handshakeId && protocol <= loginId ? STATES[protocol - handshakeId] : null;
+    public static EnumProtocol isValidIntention(int state) {
+        return state >= handshakeId && state <= loginId ? STATES[state - handshakeId] : null;
     }
 
     static {

--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/LazyInitVar.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/LazyInitVar.java
@@ -1,0 +1,21 @@
+package net.minecraft.server;
+
+import java.util.function.Supplier;
+
+public class LazyInitVar<T> {
+    private T value;
+    private boolean cached = false;
+    private final Supplier<T> supplier;
+
+    public LazyInitVar(Supplier<T> supplier) {
+        this.supplier = supplier;
+    }
+
+    public T get() {
+        if (!this.cached) {
+            this.cached = true;
+            this.value = this.supplier.get();
+        }
+        return this.value;
+    }
+}

--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/NetworkManager.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/NetworkManager.java
@@ -37,30 +37,15 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet> {
     public static final AttributeKey<EnumProtocol> ATTRIBUTE_PROTOCOL = AttributeKey.valueOf("protocol");
     public static final AttributeKey<EnumProtocol> c = ATTRIBUTE_PROTOCOL;
     // Nacho start - gave LazyInitVars a type
-    public static final LazyInitVar<NioEventLoopGroup> NETWORK_WORKER_GROUP = new LazyInitVar<NioEventLoopGroup>() {
-        protected NioEventLoopGroup a() {
-            return new NioEventLoopGroup(0, (new ThreadFactoryBuilder()).setNameFormat("Netty Client IO #%d").setDaemon(true).build());
-        }
-        protected NioEventLoopGroup init() {
-            return this.a();
-        }
-    };
-    public static final LazyInitVar<EpollEventLoopGroup> NETWORK_EPOLL_WORKER_GROUP = new LazyInitVar<EpollEventLoopGroup>() {
-        protected EpollEventLoopGroup a() {
-            return new EpollEventLoopGroup(0, (new ThreadFactoryBuilder()).setNameFormat("Netty Epoll Client IO #%d").setDaemon(true).build());
-        }
-        protected EpollEventLoopGroup init() {
-            return this.a();
-        }
-    };
-    public static final LazyInitVar<DefaultEventLoopGroup> LOCAL_WORKER_GROUP = new LazyInitVar<DefaultEventLoopGroup>() {
-        protected DefaultEventLoopGroup a() {
-            return new DefaultEventLoopGroup(0, (new ThreadFactoryBuilder()).setNameFormat("Netty Local Client IO #%d").setDaemon(true).build());
-        }
-        protected DefaultEventLoopGroup init() {
-            return this.a();
-        }
-    };
+    public static final LazyInitVar<NioEventLoopGroup> NETWORK_WORKER_GROUP = new LazyInitVar<>(() ->
+            new NioEventLoopGroup(0, (new ThreadFactoryBuilder()).setNameFormat("Netty Client IO #%d").setDaemon(true).build())
+    );
+    public static final LazyInitVar<EpollEventLoopGroup> NETWORK_EPOLL_WORKER_GROUP = new LazyInitVar<>(() ->
+            new EpollEventLoopGroup(0, (new ThreadFactoryBuilder()).setNameFormat("Netty Epoll Client IO #%d").setDaemon(true).build())
+    );
+    public static final LazyInitVar<DefaultEventLoopGroup> LOCAL_WORKER_GROUP = new LazyInitVar<>(() ->
+            new DefaultEventLoopGroup(0, (new ThreadFactoryBuilder()).setNameFormat("Netty Local Client IO #%d").setDaemon(true).build())
+    );
     // Nacho end
 
     private final EnumProtocolDirection h;

--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/NetworkManager.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/NetworkManager.java
@@ -228,7 +228,7 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet> {
     }
     // Paper / Nacho end
 
-    public void dispatchPacket(final Packet packet, final GenericFutureListener<? extends Future<? super Void>>[] listeners, Boolean flushConditional) {
+    public void dispatchPacket(final Packet<?> packet, final GenericFutureListener<? extends Future<? super Void>>[] listeners, Boolean flushConditional) {
         this.packetWrites.getAndIncrement(); // must be before using canFlush
         boolean effectiveFlush = flushConditional == null ? this.canFlush : flushConditional;
         final boolean flush = effectiveFlush || packet instanceof PacketPlayOutKeepAlive || packet instanceof PacketPlayOutKickDisconnect; // no delay for certain packets

--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/PacketDecoder.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/PacketDecoder.java
@@ -24,14 +24,14 @@ public class PacketDecoder extends ByteToMessageDecoder {
 
         PacketDataSerializer packetDataHelper = new PacketDataSerializer(in);
         int packetId = packetDataHelper.readVarInt();
-        Packet packet = ctx.channel().attr(NetworkManager.ATTRIBUTE_PROTOCOL).get().a(this.c, packetId);
+        Packet<?> packet = ctx.channel().attr(NetworkManager.ATTRIBUTE_PROTOCOL).get().createPacket(this.c, packetId);
         if (packet == null)
             throw new IOException("Bad packet id " + packetId);
 
         packet.a(packetDataHelper);
 
         if (packetDataHelper.isReadable())
-            throw new IOException("Packet " + ctx.channel().attr(NetworkManager.ATTRIBUTE_PROTOCOL).get().getProtocolId() + "/" + packetId + " (" + packet.getClass().getSimpleName() + ") was larger than I expected, found " + packetDataHelper.readableBytes() + " bytes extra whilst reading packet " + packetId);
+            throw new IOException("Packet " + ctx.channel().attr(NetworkManager.ATTRIBUTE_PROTOCOL).get().getStateId() + "/" + packetId + " (" + packet.getClass().getSimpleName() + ") was larger than I expected, found " + packetDataHelper.readableBytes() + " bytes extra whilst reading packet " + packetId);
         out.add(packet);
     }
 

--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/PacketEncoder.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/PacketEncoder.java
@@ -5,10 +5,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToByteEncoder;
 import java.io.IOException;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.Marker;
-import org.apache.logging.log4j.MarkerManager;
 
 public class PacketEncoder extends MessageToByteEncoder<Packet<?>> {
 
@@ -21,17 +17,17 @@ public class PacketEncoder extends MessageToByteEncoder<Packet<?>> {
     }
 
     protected void a(ChannelHandlerContext ctx, Packet<?> packet, ByteBuf bytebuf) throws Exception {
-        Integer integer = ctx.channel().attr(NetworkManager.ATTRIBUTE_PROTOCOL).get().a(this.c, packet);
+        Integer packetId = ctx.channel().attr(NetworkManager.ATTRIBUTE_PROTOCOL).get().getPacketIdForPacket(packet);
 
         /*if (PacketEncoder.a.isDebugEnabled()) {
-            PacketEncoder.a.debug(PacketEncoder.b, "OUT: [{}:{}] {}", ctx.channel().attr(NetworkManager.ATTRIBUTE_PROTOCOL).get(), integer, packet.getClass().getName());
+            PacketEncoder.a.debug(PacketEncoder.b, "OUT: [{}:{}] {}", ctx.channel().attr(NetworkManager.ATTRIBUTE_PROTOCOL).get(), packetId, packet.getClass().getName());
         }*/
 
-        if (integer == null) {
+        if (packetId == null) {
             throw new IOException("Can't serialize unregistered packet");
         } else {
             PacketDataSerializer serializer = new PacketDataSerializer(bytebuf);
-            serializer.b(integer);
+            serializer.b(packetId);
 
             try {
                 packet.b(serializer);

--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/PacketHandshakingInSetProtocol.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/PacketHandshakingInSetProtocol.java
@@ -22,7 +22,7 @@ public class PacketHandshakingInSetProtocol implements Packet<PacketHandshakingI
         serializer.b(this.a);
         serializer.a(this.hostname);
         serializer.writeShort(this.port);
-        serializer.b(this.d.getProtocolId());
+        serializer.b(this.d.getStateId());
     }
 
     public void a(PacketHandshakingInListener packethandshakinginlistener) {

--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/ServerConnection.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/ServerConnection.java
@@ -40,11 +40,10 @@ public class ServerConnection {
 
     public static LazyInitVar<EventLoopGroup> a, b; // a = boss, b = worker
 
-    public static final LazyInitVar<DefaultEventLoopGroup> c = new LazyInitVar<DefaultEventLoopGroup>() {
-        protected DefaultEventLoopGroup init() {
-            return new DefaultEventLoopGroup(0, (new ThreadFactoryBuilder()).setNameFormat("Netty Local Server IO #%d").setDaemon(true).build());
-        }
-    };
+
+    public static final LazyInitVar<DefaultEventLoopGroup> c = new LazyInitVar<>(() ->
+            new DefaultEventLoopGroup(0, (new ThreadFactoryBuilder()).setNameFormat("Netty Local Server IO #%d").setDaemon(true).build())
+    );
 
     public final MinecraftServer server;
     public volatile boolean started;
@@ -98,18 +97,8 @@ public class ServerConnection {
 
                     case EPOLL: {
                         if (Epoll.isAvailable()) {
-                            a = new LazyInitVar<EventLoopGroup>() {
-                                @Override
-                                protected EventLoopGroup init() {
-                                    return new EpollEventLoopGroup(2);
-                                }
-                            };
-                            b = new LazyInitVar<EventLoopGroup>() {
-                                @Override
-                                protected EventLoopGroup init() {
-                                    return new EpollEventLoopGroup(workerThreadCount);
-                                }
-                            };
+                            a = new LazyInitVar<>(() -> new EpollEventLoopGroup(2));
+                            b = new LazyInitVar<>(() -> new EpollEventLoopGroup(workerThreadCount));
 
                             channel = EpollServerSocketChannel.class;
 
@@ -120,18 +109,8 @@ public class ServerConnection {
                     }
                     case KQUEUE: {
                         if (KQueue.isAvailable()) {
-                            a = new LazyInitVar<EventLoopGroup>() {
-                                @Override
-                                protected EventLoopGroup init() {
-                                    return new KQueueEventLoopGroup(2);
-                                }
-                            };
-                            b = new LazyInitVar<EventLoopGroup>() {
-                                @Override
-                                protected EventLoopGroup init() {
-                                    return new KQueueEventLoopGroup(workerThreadCount);
-                                }
-                            };
+                            a = new LazyInitVar<>(() -> new KQueueEventLoopGroup(2));
+                            b = new LazyInitVar<>(() -> new KQueueEventLoopGroup(workerThreadCount));
 
                             channel = KQueueServerSocketChannel.class;
 
@@ -141,18 +120,8 @@ public class ServerConnection {
                         }
                     }
                     case NIO: {
-                        a = new LazyInitVar<EventLoopGroup>() {
-                            @Override
-                            protected EventLoopGroup init() {
-                                return new NioEventLoopGroup(2);
-                            }
-                        };
-                        b = new LazyInitVar<EventLoopGroup>() {
-                            @Override
-                            protected EventLoopGroup init() {
-                                return new NioEventLoopGroup(workerThreadCount);
-                            }
-                        };
+                        a = new LazyInitVar<>(() -> new NioEventLoopGroup(2));
+                        b = new LazyInitVar<>(() -> new NioEventLoopGroup(workerThreadCount));
 
                         channel = NioServerSocketChannel.class;
 
@@ -167,7 +136,7 @@ public class ServerConnection {
                     .channel(channel))
                     .childOption(ChannelOption.WRITE_BUFFER_WATER_MARK, SERVER_WRITE_MARK)
                     .childHandler(new MinecraftPipeline(this))
-                    .group(a.c(), b.c())
+                    .group(a.get(), b.get())
                     .localAddress(ip, port))
                     .bind()
                     .syncUninterruptibly());
@@ -181,9 +150,9 @@ public class ServerConnection {
             try {
                 channelfuture.channel().close().sync();
             } finally {
-                a.c().shutdownGracefully();
-                b.c().shutdownGracefully();
-                c.c().shutdownGracefully();
+                a.get().shutdownGracefully();
+                b.get().shutdownGracefully();
+                c.get().shutdownGracefully();
             }
         }
 


### PR DESCRIPTION
Optimizing packet sending and receiving by using suppliers instead of Reflection.
Also remapped EnumProtocol to get a better understanding of it.

Since my recode broke ProtocolLib's packet registry, I've added a shim for it.
One caveat is that we now have an extra map, so extra memory has to be allocated.
There's a config option for this, so if you don't have ProtocolLib, I recommend you disable this.