### PR TITLE
Remove FastMath sin and cos config

### DIFF
--- a/NachoSpigot-Server/src/main/java/me/elier/nachospigot/config/NachoConfig.java
+++ b/NachoSpigot-Server/src/main/java/me/elier/nachospigot/config/NachoConfig.java
@@ -50,7 +50,7 @@ public class NachoConfig {
         File old_config = new File("nacho.json");
         if(old_config.exists()) migrate(old_config);
 
-        int configVersion = 5; // Update this every new configuration update
+        int configVersion = 6; // Update this every new configuration update
         version = getInt("config-version", configVersion);
         set("config-version", configVersion);
         c.setHeader(HEADER);
@@ -349,13 +349,6 @@ public class NachoConfig {
     private static void enableFastMath() {
         enableFastMath = getBoolean("settings.enable-fastmath", false);
         c.addComment("settings.enable-fastmath", "Enable Fast Math usage.");
-    }
-
-    public static boolean enableFastMathCosSin;
-
-    private static void enableFastMathCosSin() {
-        enableFastMathCosSin = getBoolean("settings.enable-fastmath-cos-sin", false);
-        c.addComment("settings.enable-fastmath-cos-sin", "Enable Fast Math usage with cos() and sin() methods, this may break anticheats and server-side calculations.");
     }
 
     public static int tileEntityTickingTime;

--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/MathHelper.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/MathHelper.java
@@ -13,14 +13,13 @@ public class MathHelper {
     private static final double[] e;
     private static final double[] f;
     private static final boolean fastMathMode = NachoConfig.enableFastMath;
-    private static final boolean fastMathCosSin = NachoConfig.enableFastMathCosSin;
 
     public static float sin(float var0) {
-        return (fastMathCosSin ? ((float) FastMath.sinQuick(b[(int)(var0 * 10430.378F) & '\uffff'])) : (b[(int)(var0 * 10430.378F) & '\uffff']));
+        return b[(int)(var0 * 10430.378F) & '\uffff'];
     }
 
     public static float cos(float var0) {
-        return (fastMathCosSin ? ((float) FastMath.cosQuick(b[(int)(var0 * 10430.378F + 16384.0F) & '\uffff'])) : (b[(int)(var0 * 10430.378F + 16384.0F) & '\uffff']));
+        return b[(int)(var0 * 10430.378F + 16384.0F) & '\uffff'];
     }
 
     public static float c(float var0) {
@@ -298,11 +297,7 @@ public class MathHelper {
     static {
         int var0;
         for(var0 = 0; var0 < 65536; ++var0) {
-            if (fastMathCosSin) {
-                b[var0] = (float) FastMath.sinQuick((double) var0 * FastMath.PI * 2.0D / 65536.0D);
-            } else {
-                b[var0] = (float) Math.sin((double) var0 * 3.141592653589793D * 2.0D / 65536.0D);
-            }
+            b[var0] = (float) Math.sin((double) var0 * 3.141592653589793D * 2.0D / 65536.0D);
         }
 
         c = new int[]{0, 1, 28, 2, 29, 14, 24, 3, 30, 22, 20, 15, 25, 17, 4, 8, 31, 27, 13, 23, 21, 19, 16, 7, 26, 12, 18, 6, 11, 5, 10, 9};
@@ -312,10 +307,9 @@ public class MathHelper {
 
         for(var0 = 0; var0 < 257; ++var0) {
             double var1 = (double) var0 / 256.0D;
-            double var3 = (fastMathCosSin ? (FastMath.asin(var1)) : (Math.asin(var1)));
-            f[var0] = (fastMathCosSin ? (FastMath.cosQuick(var3)) : (Math.cos(var3)));
+            double var3 = (fastMathMode ? (FastMath.asin(var1)) : (Math.asin(var1)));
+            f[var0] = Math.cos(var3);
             e[var0] = var3;
         }
-
     }
 }


### PR DESCRIPTION
# Description

This PR removes FastMath's con and sin methods. This is done due to the fact that FastMath's con and sin gives [less performance and inaccurate results](https://github.com/CobbleSword/NachoSpigot/files/7550597/fastmathvsvanilla.txt). 

Fixes #244 

# How has this been tested?

I have tested #244.

# Checklist:

- [x] I have reviewed my code thoroughly.
- [x] I have tested my code.
- [x] My changes generate no new warnings
