### PR TITLE
fix comments and enforce proper usage of them

### DIFF
--- a/NachoSpigot-Server/pom.xml
+++ b/NachoSpigot-Server/pom.xml
@@ -120,11 +120,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>net.jafama</groupId>
-            <artifactId>jafama</artifactId>
-            <version>2.3.2</version>
-        </dependency>
-        <dependency>
             <groupId>com.eatthepath</groupId>
             <artifactId>fast-uuid</artifactId>
             <version>0.2.0</version>
@@ -290,6 +285,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.0.0-M5</version>
                 <configuration>
+                    <trimStackTrace>false</trimStackTrace>
                     <workingDirectory>${basedir}/target/test-server</workingDirectory>
                     <excludes>
                         <exclude>org/bukkit/craftbukkit/inventory/ItemStack*Test.java</exclude>

--- a/NachoSpigot-Server/pom.xml
+++ b/NachoSpigot-Server/pom.xml
@@ -45,6 +45,19 @@
         </dependency>
 
         <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm</artifactId>
+            <version>9.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-util</artifactId>
+            <version>9.2</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.12.0</version>

--- a/NachoSpigot-Server/src/main/java/me/elier/nachospigot/config/NachoConfig.java
+++ b/NachoSpigot-Server/src/main/java/me/elier/nachospigot/config/NachoConfig.java
@@ -15,7 +15,6 @@ import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.nio.file.Files;
 import java.util.List;
 
 public class NachoConfig {
@@ -54,8 +53,8 @@ public class NachoConfig {
         version = getInt("config-version", configVersion);
         set("config-version", configVersion);
         c.setHeader(HEADER);
-        c.addComment("config-version", "Configuration version, do NOT modify this!");
         readConfig(NachoConfig.class, null);
+        loadComments();
     }
 
     private static void migrate(File old_config) {
@@ -101,8 +100,48 @@ public class NachoConfig {
         set("world-settings.default.disable-sponge-absorption", nachoJson.disableSpongeAbsorption);
         set("settings.fix-eat-while-running", nachoJson.fixEatWhileRunning);
         set("settings.hide-projectiles-from-hidden-players", nachoJson.hideProjectilesFromHiddenPlayers);
-        set("settings.instant-use-entity", nachoJson.hideProjectilesFromHiddenPlayers);
         old_config.delete();
+    }
+
+    static void loadComments() {
+        c.addComment("config-version", "Configuration version, do NOT modify this!");
+        c.addComment("settings.save-empty-scoreboard-teams", "Toggles whether or not the server should save empty scoreboard teams");
+        c.addComment("settings.commands.enable-version-command", "Toggles the /version command");
+        c.addComment("settings.commands.enable-plugins-command", "Toggles the /plugins command");
+        c.addComment("settings.commands.enable-reload-command", "Toggles the /reload command");
+        c.addComment("settings.fast-operators", "Enables Fast Operators, which uses a faster method for managing operators");
+        c.addComment("settings.patch-protocollib", "Enables the ProtocolLib runtime patch (not required on ProtocolLib version 4.7+)");
+        c.addComment("settings.stop-notify-bungee", "Disables the firewall check when running BungeeCord");
+        c.addComment("settings.anti-malware", "Enables the built-in anti malware feature");
+        c.addComment("settings.kick-on-illegal-behavior", "Kicks players if they try to do an illegal action (e.g. using a creative mode action while not in creative mode.)");
+        c.addComment("settings.panda-wire", "Optimizes redstone wires.");
+        c.addComment("settings.event.fire-entity-explode-event", "Toggles the entity explode event");
+        c.addComment("settings.event.fire-player-move-event", "Toggles the player move event");
+        c.addComment("settings.event.fire-leaf-decay-event", "Toggles the leaf decay event");
+        c.addComment("settings.player-time-statistics-interval", "Changes when statistics are ticked (e.g. 20 would be every 20th tick)");
+        c.addComment("settings.brand-name", "Changes the brand name of the server.\nThis will show in statistics, server lists, client crashes,\n and in the client debug screen. (accessed by pressing F3)");
+        c.addComment("settings.stop-decoding-itemstack-on-place", "Disables decoding itemstacks when not needed");
+        c.addComment("settings.anti-crash", "Kicks players if they try to do an action that would/might crash the server");
+        c.addComment("settings.chunk.threads", "The amount of threads used for chunks");
+        c.addComment("settings.chunk.players-per-thread", "The amount of players for each thread");
+        c.addComment("settings.use-tcp-nodelay", "Enables the TCP_NODELAY socket option");
+        c.addComment("settings.fixed-pools.use-fixed-pools-for-explosions", "Enables fixed thread pool for explosions");
+        c.addComment("settings.fixed-pools.size", "The size for the fixed thread pool for explosions.");
+        c.addComment("settings.faster-cannon-tracker", "Enables a faster cannon entity tracker");
+        c.addComment("settings.fix-eat-while-running", "Fixes the eating while running bug");
+        c.addComment("settings.hide-projectiles-from-hidden-players", "Hides projectiles from hidden players");
+        c.addComment("settings.anti-enderpearl-glitch", "Enables anti enderpearl glitch");
+        c.addComment("settings.disabled-block-fall-animation", "Disables the fall animation for blocks");
+        c.addComment("settings.enable-protocollib-shim", "Enable ProtocolLib network shim. Allows ProtocolLib to work, but requires extra memory. Disable this if you don't use ProtocolLib!");
+        c.addComment("settings.instant-interaction", "Disables delay of all interactions");
+        c.addComment("settings.disable-infinisleeper-thread-usage", "Disable infinisleeper thread usage, just enable this if you know what are you doing.");
+        c.addComment("settings.enable-fastmath", "Enable Fast Math usage.");
+        c.addComment("settings.use-tcp-fastopen", "Options: 0 - Disabled.; 1 - TFO is enabled for outgoing connections (clients).; 2 - TFO is enabled for incoming connections (servers).; 3 - TFO is enabled for both clients and servers.");
+        c.addComment("settings.enable-fastmath-cos-sin", "Enable Fast Math usage with cos() and sin() methods, this may break anticheats and server-side calculations.");
+        c.addComment("settings.tile-entity-ticking-time", "Ticking time (20 ticks per second) for usage on tile entity operations.");
+        c.addComment("settings.item-dirty-ticks", "Controls the interval for the item-dirty check. Minecraft checks an item every tick to see if it was changed. This can be expensive because it also needs to check all NBT data. Spigot only checks for basic count/data/type data and does a deep check every 20 ticks by default.");
+        c.addComment("settings.use-tcp-fastopen", "Enables the TCP_FASTOPEN socket option");
+        NachoWorldConfig.loadComments();
     }
 
     static void readConfig(Class<?> clazz, Object instance) {
@@ -123,7 +162,7 @@ public class NachoConfig {
 
         try {
             config.save(CONFIG_FILE);
-            //c.saveComments(CONFIG_FILE);
+            c.saveComments(CONFIG_FILE);
         } catch (IOException ex) {
             LOGGER.log(Level.ERROR, "Could not save " + CONFIG_FILE, ex);
         }
@@ -167,7 +206,6 @@ public class NachoConfig {
 
     private static void saveEmptyScoreboardTeams() {
         saveEmptyScoreboardTeams = getBoolean("settings.save-empty-scoreboard-teams", false);
-        c.addComment("settings.save-empty-scoreboard-teams", "Toggles whether or not the server should save empty scoreboard teams");
     }
     public static boolean enableVersionCommand;
     public static boolean enablePluginsCommand;
@@ -175,50 +213,41 @@ public class NachoConfig {
 
     private static void commands() {
         enableVersionCommand = getBoolean("settings.commands.enable-version-command", true);
-        c.addComment("settings.commands.enable-version-command", "Toggles the /version command");
         enablePluginsCommand = getBoolean("settings.commands.enable-plugins-command", true);
-        c.addComment("settings.commands.enable-plugins-command", "Toggles the /plugins command");
         enableReloadCommand = getBoolean("settings.commands.enable-reload-command", true);
-        c.addComment("settings.commands.enable-reload-command", "Toggles the /reload command");
     }
 
     public static boolean useFastOperators;
 
     private static void useFastOperators() {
         useFastOperators = getBoolean("settings.fast-operators", false);
-        c.addComment("settings.fast-operators", "Enables Fast Operators, which uses a faster method for managing operators");
     }
     public static boolean patchProtocolLib;
 
     private static void patchProtocolLib() {
         patchProtocolLib = getBoolean("settings.patch-protocollib", true);
-        c.addComment("settings.patch-protocollib", "Enables the ProtocolLib runtime patch (not required on ProtocolLib version 4.7+)");
     }
     public static boolean stopNotifyBungee;
 
     private static void stopNotifyBungee() {
         stopNotifyBungee = getBoolean("settings.stop-notify-bungee", false);
-        c.addComment("settings.stop-notify-bungee", "Disables the firewall check when running BungeeCord");
     }
     public static boolean checkForMalware;
 
     private static void antiMalware() {
         checkForMalware = getBoolean("settings.anti-malware", false);
-        c.addComment("settings.anti-malware", "Enables the built-in anti malware feature");
     }
 
     public static boolean kickOnIllegalBehavior;
 
     private static void kickOnIllegalBehavior() {
         kickOnIllegalBehavior = getBoolean("settings.kick-on-illegal-behavior", true);
-        c.addComment("settings.kick-on-illegal-behavior", "Kicks players if they try to do an illegal action (e.g. using a creative mode action while not in creative mode.)");
     }
 
     public static boolean usePandaWire;
 
     private static void usePandaWire() {
         usePandaWire = getBoolean("settings.panda-wire", true);
-        c.addComment("settings.panda-wire", "Optimizes redstone wires.");
     }
 
     public static boolean fireEntityExplodeEvent;
@@ -227,39 +256,32 @@ public class NachoConfig {
 
     private static void fireEntityExplodeEvent() {
         fireEntityExplodeEvent = getBoolean("settings.event.fire-entity-explode-event", true);
-        c.addComment("settings.event.fire-entity-explode-event", "Toggles the entity explode event");
         firePlayerMoveEvent = getBoolean("settings.event.fire-player-move-event", true);
-        c.addComment("settings.event.fire-player-move-event", "Toggles the player move event");
         leavesDecayEvent = getBoolean("settings.event.fire-leaf-decay-event", true);
-        c.addComment("settings.event.fire-leaf-decay-event", "Toggles the leaf decay event");
     }
 
     public static int playerTimeStatisticsInterval;
 
     private static void playerTimeStatisticsInterval() {
         playerTimeStatisticsInterval = getInt("settings.player-time-statistics-interval", 20);
-        c.addComment("settings.player-time-statistics-interval", "Changes when statistics are ticked (e.g. 20 would be every 20th tick)");
     }
 
     public static String serverBrandName;
 
     private static void serverBrandName() {
         serverBrandName = getString("settings.brand-name", "NachoSpigot");
-        c.addComment("settings.brand-name", "Changes the brand name of the server.\nThis will show in statistics, server lists, client crashes,\n and in the client debug screen. (accessed by pressing F3)");
     }
 
     public static boolean stopDecodingItemStackOnPlace;
 
     private static void stopDecodingItemStackOnPlace() {
         stopDecodingItemStackOnPlace = getBoolean("settings.stop-decoding-itemstack-on-place", true);
-        c.addComment("settings.stop-decoding-itemstack-on-place", "Disables decoding itemstacks when not needed");
     }
 
     public static boolean enableAntiCrash;
 
     private static void enableAntiCrash() {
         enableAntiCrash = getBoolean("settings.anti-crash", true);
-        c.addComment("settings.anti-crash", "Kicks players if they try to do an action that would/might crash the server");
     }
 
     public static int chunkThreads; // PaperSpigot - Bumped value
@@ -267,16 +289,13 @@ public class NachoConfig {
 
     private static void chunk() {
         chunkThreads = getInt("settings.chunk.threads", 2);
-        c.addComment("settings.chunk.threads", "The amount of threads used for chunks");
         playersPerThread = getInt("settings.chunk.players-per-thread", 50);
-        c.addComment("settings.chunk.players-per-thread", "The amount of players for each thread");
     }
 
     public static boolean enableTCPNODELAY;
 
     private static void enableTCPNODELAY() {
         enableTCPNODELAY = getBoolean("settings.use-tcp-nodelay", true);
-        c.addComment("settings.use-tcp-nodelay", "Enables the TCP_NODELAY socket option");
     }
 
     public static boolean useFixedPoolForTNT;
@@ -284,29 +303,24 @@ public class NachoConfig {
 
     private static void fixedPools() {
         useFixedPoolForTNT = getBoolean("settings.fixed-pools.use-fixed-pools-for-explosions", false);
-        c.addComment("settings.fixed-pools.use-fixed-pools-for-explosions", "Enables fixed thread pool for explosions");
         fixedPoolSize = getInt("settings.fixed-pools.size", 500);
-        c.addComment("settings.fixed-pools.size", "The size for the fixed thread pool for explosions.");
     }
     public static boolean useFasterCannonTracker;
 
     private static void useFasterCannonTracker() {
         useFasterCannonTracker = getBoolean("settings.faster-cannon-tracker", true);
-        c.addComment("settings.faster-cannon-tracker", "Enables a faster cannon entity tracker");
     }
 
     public static boolean fixEatWhileRunning;
 
     private static void fixEatWhileRunning() {
         fixEatWhileRunning = getBoolean("settings.fix-eat-while-running", false);
-        c.addComment("settings.fix-eat-while-running", "Fixes the eating while running bug");
     }
 
     public static boolean hideProjectilesFromHiddenPlayers;
 
     private static void hideProjectilesFromHiddenPlayers() {
         hideProjectilesFromHiddenPlayers = getBoolean("settings.hide-projectiles-from-hidden-players", false);
-        c.addComment("settings.hide-projectiles-from-hidden-players", "Hides projectiles from hidden players");
     }
 
     public static boolean lagCompensatedPotions;
@@ -327,76 +341,65 @@ public class NachoConfig {
     
     private static void antiEnderPearlGlitch() {
         antiEnderPearlGlitch = getBoolean("settings.anti-enderpearl-glitch", false);
-        c.addComment("settings.anti-enderpearl-glitch", "Enables anti enderpearl glitch");
     }
 
     public static boolean disabledFallBlockAnimation;
 
     private static void disableFallAnimation() {
         disabledFallBlockAnimation = getBoolean("settings.disabled-block-fall-animation", false);
-        c.addComment("settings.disabled-block-fall-animation", "Disables the fall animation for blocks");
     }
 
     public static boolean disableInfiniSleeperThreadUsage;
 
     private static void disableInfiniSleeperThreadUsage() {
         disableInfiniSleeperThreadUsage = getBoolean("settings.disable-infinisleeper-thread-usage", false);
-        c.addComment("settings.disable-infinisleeper-thread-usage", "Disable infinisleeper thread usage, just enable this if you know what are you doing.");
     }
 
     public static boolean enableFastMath;
 
     private static void enableFastMath() {
         enableFastMath = getBoolean("settings.enable-fastmath", false);
-        c.addComment("settings.enable-fastmath", "Enable Fast Math usage.");
     }
 
     public static boolean enableFastMathCosSin;
 
     private static void enableFastMathCosSin() {
         enableFastMathCosSin = getBoolean("settings.enable-fastmath-cos-sin", false);
-        c.addComment("settings.enable-fastmath-cos-sin", "Enable Fast Math usage with cos() and sin() methods, this may break anticheats and server-side calculations.");
     }
 
-    public static int tileEntityTickingTime;
+    public static int tileEntityTickingTime = 20; // required to be initialized so tests don't fail
 
     private static void tileEntityTickingTime() {
         tileEntityTickingTime = getInt("settings.tile-entity-ticking-time", 20);
-        c.addComment("settings.tile-entity-ticking-time", "Ticking time (20 ticks per second) for usage on tile entity operations.");
     }
 
     public static int itemDirtyTicks;
 
     private static void itemDirtyTicks() {
         itemDirtyTicks = getInt("settings.item-dirty-ticks", 20);
-        c.addComment("settings.item-dirty-ticks", "Controls the interval for the item-dirty check. Minecraft checks an item every tick to see if it was changed. This can be expensive because it also needs to check all NBT data. Spigot only checks for basic count/data/type data and does a deep check every 20 ticks by default.");
     }
 
     public static boolean enableTcpFastOpen;
 
     private static void enableTcpFastOpen() {
         enableTcpFastOpen = getBoolean("settings.use-tcp-fastopen", true);
-        c.addComment("settings.use-tcp-fastopen", "Enables the TCP_FASTOPEN socket option");
     }
 
     public static int modeTcpFastOpen;
 
     private static void modeTcpFastOpen() {
         modeTcpFastOpen = getInt("settings.tcp-fastopen-mode", 1);
-        c.addComment("settings.use-tcp-fastopen", "Options: 0 - Disabled.; 1 - TFO is enabled for outgoing connections (clients).; 2 - TFO is enabled for incoming connections (servers).; 3 - TFO is enabled for both clients and servers.");
     }
 
     public static boolean enableProtocolLibShim;
 
     private static void enableProtocolLibShim() {
         enableProtocolLibShim = getBoolean("settings.enable-protocollib-shim", true);
-        c.addComment("settings.enable-protocollib-shim", "Enable ProtocolLib network shim. Allows ProtocolLib to work, but requires extra memory. Disable this if you don't use ProtocolLib!");
     }
 
     public static boolean instantPlayInUseEntity;
 
     private static void instantPlayInUseEntity() {
         instantPlayInUseEntity = getBoolean("settings.instant-interaction", false);
-        c.addComment("settings.instant-interaction", "Disables delay of all interactions");
     }
 }

--- a/NachoSpigot-Server/src/main/java/me/elier/nachospigot/config/NachoConfig.java
+++ b/NachoSpigot-Server/src/main/java/me/elier/nachospigot/config/NachoConfig.java
@@ -141,6 +141,8 @@ public class NachoConfig {
         c.addComment("settings.tile-entity-ticking-time", "Ticking time (20 ticks per second) for usage on tile entity operations.");
         c.addComment("settings.item-dirty-ticks", "Controls the interval for the item-dirty check. Minecraft checks an item every tick to see if it was changed. This can be expensive because it also needs to check all NBT data. Spigot only checks for basic count/data/type data and does a deep check every 20 ticks by default.");
         c.addComment("settings.use-tcp-fastopen", "Enables the TCP_FASTOPEN socket option");
+        c.addComment("settings.lag-compensated-potions", "Enables lag compesation throwing potions");
+        c.addComment("settings.smooth-potting", "Make potion throwing smoother");
         NachoWorldConfig.loadComments();
     }
 
@@ -327,14 +329,12 @@ public class NachoConfig {
     
     private static void lagCompensatedPotions() {
         lagCompensatedPotions = getBoolean("settings.lag-compensated-potions", false);
-        c.addComment("settings.lag-compensated-potions", "Enables lag compesation throwing potions");
     }
 
     public static boolean smoothPotting;
     
     private static void smoothPotting() {
         smoothPotting = getBoolean("settings.smooth-potting", false);
-        c.addComment("settings.smooth-potting", "Make potion throwing smoother");
     }
 
     public static boolean antiEnderPearlGlitch;

--- a/NachoSpigot-Server/src/main/java/me/elier/nachospigot/config/NachoConfig.java
+++ b/NachoSpigot-Server/src/main/java/me/elier/nachospigot/config/NachoConfig.java
@@ -17,6 +17,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.List;
 
+@SuppressWarnings("unused")
 public class NachoConfig {
 
     private static final Logger LOGGER = LogManager.getLogger(NachoConfig.class);
@@ -57,7 +58,7 @@ public class NachoConfig {
         loadComments();
     }
 
-    private static void migrate(File old_config) {
+    static void migrate(File old_config) {
         OldNachoConfig nachoJson = FileUtils.toObject(old_config, OldNachoConfig.class);
         if(nachoJson == null) {old_config.delete(); return;}
         set("settings.save-empty-scoreboard-teams", nachoJson.saveEmptyScoreboardTeams);
@@ -170,36 +171,36 @@ public class NachoConfig {
         }
     }
 
-    private static void set(String path, Object val) {
+    static void set(String path, Object val) {
         config.set(path, val);
     }
 
-    private static boolean getBoolean(String path, boolean def) {
+    static boolean getBoolean(String path, boolean def) {
         config.addDefault(path, def);
         return config.getBoolean(path, config.getBoolean(path));
     }
 
-    private static double getDouble(String path, double def) {
+    static double getDouble(String path, double def) {
         config.addDefault(path, def);
         return config.getDouble(path, config.getDouble(path));
     }
 
-    private static float getFloat(String path, float def) {
+    static float getFloat(String path, float def) {
         config.addDefault(path, def);
         return config.getFloat(path, config.getFloat(path));
     }
 
-    private static int getInt(String path, int def) {
+    static int getInt(String path, int def) {
         config.addDefault(path, def);
         return config.getInt(path, config.getInt(path));
     }
 
-    private static <T> List getList(String path, T def) {
+    static <T> List getList(String path, T def) {
         config.addDefault(path, def);
         return config.getList(path, config.getList(path));
     }
 
-    private static String getString(String path, String def) {
+    static String getString(String path, String def) {
         config.addDefault(path, def);
         return config.getString(path, config.getString(path));
     }

--- a/NachoSpigot-Server/src/main/java/me/elier/nachospigot/config/NachoConfig.java
+++ b/NachoSpigot-Server/src/main/java/me/elier/nachospigot/config/NachoConfig.java
@@ -138,7 +138,6 @@ public class NachoConfig {
         c.addComment("settings.disable-infinisleeper-thread-usage", "Disable infinisleeper thread usage, just enable this if you know what are you doing.");
         c.addComment("settings.enable-fastmath", "Enable Fast Math usage.");
         c.addComment("settings.use-tcp-fastopen", "Options: 0 - Disabled.; 1 - TFO is enabled for outgoing connections (clients).; 2 - TFO is enabled for incoming connections (servers).; 3 - TFO is enabled for both clients and servers.");
-        c.addComment("settings.enable-fastmath-cos-sin", "Enable Fast Math usage with cos() and sin() methods, this may break anticheats and server-side calculations.");
         c.addComment("settings.tile-entity-ticking-time", "Ticking time (20 ticks per second) for usage on tile entity operations.");
         c.addComment("settings.item-dirty-ticks", "Controls the interval for the item-dirty check. Minecraft checks an item every tick to see if it was changed. This can be expensive because it also needs to check all NBT data. Spigot only checks for basic count/data/type data and does a deep check every 20 ticks by default.");
         c.addComment("settings.use-tcp-fastopen", "Enables the TCP_FASTOPEN socket option");

--- a/NachoSpigot-Server/src/main/java/me/elier/nachospigot/config/NachoWorldConfig.java
+++ b/NachoSpigot-Server/src/main/java/me/elier/nachospigot/config/NachoWorldConfig.java
@@ -64,29 +64,44 @@ public class NachoWorldConfig {
         return config.getString("world-settings." + worldName + "." + path, config.getString("world-settings.default." + path));
     }
 
-    private void addComment(String path, String comment) {
+    private static void addComment(String path, String comment) {
         NachoConfig.c.addComment("world-settings.default." + path, comment);
+    }
+
+    static void loadComments() {
+        addComment("disable-sponge-absorption", "Disables sponge absorption");
+        addComment("unload-chunks", "Enable unloading chunks");
+        addComment("block-operations", "Enable block operations");
+        addComment("physics.disable-place", "Disables physics place");
+        addComment("physics.disable-update", "Disables physics update");
+        addComment("enable-lava-to-cobblestone", "Enables lava converting to cobblestone.");
+        addComment("entity.mob-ai", "Enables mob AI");
+        addComment("entity.mob-sound", "Enables mob sound");
+        addComment("entity.entity-activation", "Enables active ticks for entities");
+        addComment("entity.endermite-spawning", "Enables endermite spawning.");
+        addComment("infinite-water-sources", "Enables infinite water sources");
+        addComment("explosions.constant-explosions", "Changes the radius of explosions to be constant.");
+        addComment("explosions.explode-protected-regions", "Toggles whether explosions should explode protected regions");
+        addComment("explosions.reduced-density-rays", "Toggles whether the server should use reduced rays when calculating density");
+        addComment("tick-enchantment-tables", "Toggles whether enchantment tables should be ticked");
     }
 
     public boolean disableSpongeAbsorption;
 
     private void disableSpongeAbsorption() {
         disableSpongeAbsorption = getBoolean("disable-sponge-absorption", false);
-        addComment("disable-sponge-absorption", "Disables sponge absorption");
     }
 
     public boolean doChunkUnload;
 
     private void doChunkUnload() {
         doChunkUnload = getBoolean("unload-chunks", true);
-        addComment("unload-chunks", "Enable unloading chunks");
     }
 
     public boolean doBlocksOperations;
 
     private void doBlocksOperations() {
         doBlocksOperations = getBoolean("block-operations", true);
-        addComment("block-operations", "Enable block operations");
     }
 
     public boolean disablePhysicsPlace;
@@ -94,16 +109,13 @@ public class NachoWorldConfig {
 
     private void physics() {
         disablePhysicsPlace = getBoolean("physics.disable-place", false);
-        addComment("physics.disable-place", "Disables physics place");
-        disablePhysicsUpdate = getBoolean("settings.physics.disable-update", false);
-        addComment("physics.disable-update", "Disables physics update");
+        disablePhysicsUpdate = getBoolean("physics.disable-update", false);
     }
 
     public boolean enableLavaToCobblestone;
 
     private void setEnableLavaToCobblestone() {
         enableLavaToCobblestone = getBoolean("enable-lava-to-cobblestone", true);
-        addComment("enable-lava-to-cobblestone", "Enables lava converting to cobblestone.");
     }
 
     public boolean enableMobAI;
@@ -113,20 +125,15 @@ public class NachoWorldConfig {
 
     private void entity() {
         enableMobAI = getBoolean("entity.mob-ai", true);
-        addComment("entity.mob-ai", "Enables mob AI");
         enableMobSound = getBoolean("entity.mob-sound", true);
-        addComment("entity.mob-sound", "Enables mob sound");
         enableEntityActivation = getBoolean("entity.entity-activation", true);
-        addComment("entity.entity-activation", "Enables active ticks for entities");
         endermiteSpawning = getBoolean("entity.endermite-spawning", true);
-        addComment("entity.endermite-spawning", "Enables endermite spawning.");
     }
 
     public boolean infiniteWaterSources;
 
     private void infiniteWaterSources() {
         infiniteWaterSources = getBoolean("infinite-water-sources", true);
-        addComment("infinite-water-sources", "Enables infinite water sources");
     }
 
     public boolean constantExplosions;
@@ -135,17 +142,13 @@ public class NachoWorldConfig {
 
     private void explosions() {
         constantExplosions = getBoolean("explosions.constant-radius", false);
-        addComment("explosions.constant-explosions", "Changes the radius of explosions to be constant.");
         explosionProtectedRegions = getBoolean("explosions.explode-protected-regions", true);
-        addComment("explosions.explode-protected-regions", "Toggles whether explosions should explode protected regions");
         reducedDensityRays = getBoolean("explosions.reduced-density-rays", true);
-        addComment("explosions.reduced-density-rays", "Toggles whether the server should use reduced rays when calculating density");
     }
 
     public boolean shouldTickEnchantmentTables;
 
     private void shouldTickEnchantmentTables() {
         shouldTickEnchantmentTables = getBoolean("tick-enchantment-tables", true);
-        addComment("tick-enchantment-tables", "Toggles whether enchantment tables should be ticked");
     }
 }

--- a/NachoSpigot-Server/src/main/java/me/elier/nachospigot/config/NachoWorldConfig.java
+++ b/NachoSpigot-Server/src/main/java/me/elier/nachospigot/config/NachoWorldConfig.java
@@ -56,7 +56,7 @@ public class NachoWorldConfig {
 
     private <T> List getList(String path, T def) {
         config.addDefault("world-settings.default." + path, def);
-        return (List<T>) config.getList("world-settings." + worldName + "." + path, config.getList("world-settings.default." + path));
+        return config.getList("world-settings." + worldName + "." + path, config.getList("world-settings.default." + path));
     }
 
     private String getString(String path, String def) {

--- a/NachoSpigot-Server/src/main/java/me/elier/util/minecraft/CryptException.java
+++ b/NachoSpigot-Server/src/main/java/me/elier/util/minecraft/CryptException.java
@@ -1,4 +1,4 @@
-package me.elier.minecraft.util;
+package me.elier.util.minecraft;
 
 public class CryptException extends Exception {
     public CryptException(Throwable throwable) {

--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/LoginListener.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/LoginListener.java
@@ -5,8 +5,7 @@ import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.exceptions.AuthenticationUnavailableException;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
-import io.netty.util.concurrent.Future;
-import io.netty.util.concurrent.GenericFutureListener;
+
 import java.math.BigInteger;
 import java.security.PrivateKey;
 import java.util.Arrays;
@@ -16,7 +15,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import javax.crypto.SecretKey;
 
-import me.elier.minecraft.util.CryptException;
 import org.apache.commons.lang3.Validate;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/NetworkManager.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/NetworkManager.java
@@ -22,7 +22,7 @@ import java.util.Iterator;
 import java.util.Queue;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-import me.elier.minecraft.util.CryptException;
+import me.elier.util.minecraft.CryptException;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.Validate;
 import org.apache.logging.log4j.LogManager;

--- a/NachoSpigot-Server/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+++ b/NachoSpigot-Server/src/main/java/org/bukkit/craftbukkit/CraftServer.java
@@ -738,7 +738,6 @@ public final class CraftServer implements Server {
         net.techcable.tacospigot.TacoSpigotConfig.init((File) console.options.valueOf("taco-settings")); // TacoSpigot
         NachoConfig.init((File) console.options.valueOf("nacho-settings")); // NachoSpigot
         KnockbackConfig.init((File) console.options.valueOf("knockback-settings"));
-        Nacho.get(); // NachoSpigot
         for (WorldServer world : console.worlds) {
             world.worldData.setDifficulty(difficulty);
             world.setSpawnFlags(monsters, animals);
@@ -756,6 +755,7 @@ public final class CraftServer implements Server {
             world.spigotConfig.init(); // Spigot
             world.paperSpigotConfig.init(); // PaperSpigot
             world.tacoSpigotConfig.init(); // TacoSpigot
+            world.nachoSpigotConfig.init(); // NachoSpigot
         }
 
         pluginManager.clearPlugins();

--- a/NachoSpigot-Server/src/main/java/org/sugarcanemc/sugarcane/util/yaml/YamlCommenter.java
+++ b/NachoSpigot-Server/src/main/java/org/sugarcanemc/sugarcane/util/yaml/YamlCommenter.java
@@ -38,7 +38,7 @@ public class YamlCommenter {
      * Saves comments to config file
      *
      * @param file File to save to
-     * @throws IOException
+     * @throws IOException io
      */
     public void saveComments(File file) throws IOException {
         ArrayList<String> lines = (ArrayList<String>) Files.readAllLines(file.toPath());
@@ -46,7 +46,7 @@ public class YamlCommenter {
         lines.add(0, "# " + Header.replace("\n", "\n# ") + "\n");
         for (Map.Entry<String, String> _comment : comments.entrySet()) {
             int line = YamlUtils.findKey(lines, _comment.getKey());
-            if(line == -1 && _comment.getKey().startsWith("world-settings.")) continue; // If anyone knows a better fix please PR!
+            if(line == -1) continue; // If anyone knows a better fix please PR!
             String prefix = Utils.repeat(" ", getIndentation(lines.get(line))) + "# ";
             boolean noNewline = getIndentation(lines.get(line)) > getIndentation(lines.get(line - 1));
             if (line >= 0)

--- a/NachoSpigot-Server/src/main/java/org/sugarcanemc/sugarcane/util/yaml/YamlCommenter.java
+++ b/NachoSpigot-Server/src/main/java/org/sugarcanemc/sugarcane/util/yaml/YamlCommenter.java
@@ -46,7 +46,18 @@ public class YamlCommenter {
         lines.add(0, "# " + Header.replace("\n", "\n# ") + "\n");
         for (Map.Entry<String, String> _comment : comments.entrySet()) {
             int line = YamlUtils.findKey(lines, _comment.getKey());
-            if(line == -1) continue; // If anyone knows a better fix please PR!
+
+            if(line == -1) {
+                // TODO: This should be fixed soon. World settings are initialized after NachoConfig, while NachoConfig loads their comments.
+                //       This causes an issue, with comments not working for world settings, and potentially causing a OOB exception.
+                if (_comment.getKey().startsWith("world-settings.")) continue;
+
+                throw new IllegalStateException(String.format(
+                        "You are trying to add a comment to key \"%s\" which does not exist!",
+                        _comment.getKey()
+                ));
+            }
+
             String prefix = Utils.repeat(" ", getIndentation(lines.get(line))) + "# ";
             boolean noNewline = getIndentation(lines.get(line)) > getIndentation(lines.get(line - 1));
             if (line >= 0)

--- a/NachoSpigot-Server/src/main/java/org/sugarcanemc/sugarcane/util/yaml/YamlCommenter.java
+++ b/NachoSpigot-Server/src/main/java/org/sugarcanemc/sugarcane/util/yaml/YamlCommenter.java
@@ -46,6 +46,7 @@ public class YamlCommenter {
         lines.add(0, "# " + Header.replace("\n", "\n# ") + "\n");
         for (Map.Entry<String, String> _comment : comments.entrySet()) {
             int line = YamlUtils.findKey(lines, _comment.getKey());
+            if(line == -1 && _comment.getKey().startsWith("world-settings.")) continue; // If anyone knows a better fix please PR!
             String prefix = Utils.repeat(" ", getIndentation(lines.get(line))) + "# ";
             boolean noNewline = getIndentation(lines.get(line)) > getIndentation(lines.get(line - 1));
             if (line >= 0)

--- a/NachoSpigot-Server/src/test/java/me/elier/nachospigot/config/ConfigurationTests.java
+++ b/NachoSpigot-Server/src/test/java/me/elier/nachospigot/config/ConfigurationTests.java
@@ -13,11 +13,6 @@ import java.util.Objects;
 
 public class ConfigurationTests {
     private static class TestUtils {
-        public static void test() throws IOException {
-            ClassReader cr = new ClassReader(NachoConfig.class.getName());
-            cr.accept(new ConfigClassVisitor(Opcodes.ASM9), ClassReader.SKIP_FRAMES);
-        }
-
         private static class ConfigClassVisitor extends ClassVisitor {
             public ConfigClassVisitor(int api) {
                 super(api);
@@ -79,6 +74,7 @@ public class ConfigurationTests {
     // Makes sure that c.addComment is not called in any config init functions.
     @Test
     public void noAddCommentInConfigInit() throws IOException {
-        TestUtils.test();
+        ClassReader cr = new ClassReader(NachoConfig.class.getName());
+        cr.accept(new TestUtils.ConfigClassVisitor(Opcodes.ASM9), ClassReader.SKIP_FRAMES);
     }
 }

--- a/NachoSpigot-Server/src/test/java/me/elier/nachospigot/config/ConfigurationTests.java
+++ b/NachoSpigot-Server/src/test/java/me/elier/nachospigot/config/ConfigurationTests.java
@@ -3,15 +3,48 @@ package me.elier.nachospigot.config;
 import dev.cobblesword.nachospigot.OldNachoConfig;
 import dev.cobblesword.nachospigot.commons.FileUtils;
 import org.junit.Test;
+import org.objectweb.asm.*;
+import org.sugarcanemc.sugarcane.util.yaml.YamlCommenter;
 
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.util.Objects;
 
 public class ConfigurationTests {
-    private class TestUtils {
-        public void containsMethodInvocation() {
+    private static class TestUtils {
+        public static void test() throws IOException {
+            ClassReader cr = new ClassReader(NachoConfig.class.getName());
+            cr.accept(new ConfigClassVisitor(Opcodes.ASM9), ClassReader.SKIP_FRAMES);
+        }
 
+        private static class ConfigClassVisitor extends ClassVisitor {
+            public ConfigClassVisitor(int api) {
+                super(api);
+            }
+
+            @Override
+            public MethodVisitor visitMethod(int access, String methodName, String descriptor, String signature, String[] exceptions) {
+                if ((access & Opcodes.ACC_PRIVATE) != 0) {
+                    MethodVisitor mv = super.visitMethod(access, methodName, descriptor, signature, exceptions);
+                    return new MethodVisitor(Opcodes.ASM9, mv) {
+                        @Override
+                        public void visitMethodInsn(int opcode, String owner, String name, String descriptor, boolean isInterface) {
+                            if (opcode == Opcodes.INVOKEVIRTUAL && Objects.equals(owner, Type.getType(YamlCommenter.class).getInternalName())) {
+                                // This method contains an invokevirtual call to YamlCommenter, this shouldn't happen!
+                                throw new IllegalStateException(String.format(
+                                        "Method %s contains a call to YamlCommenter, which shouldn't happen! Put your comments in the loadComments function.",
+                                        methodName
+                                ));
+                            } else {
+                                super.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
+                            }
+                        }
+                    };
+                }
+
+                return super.visitMethod(access, methodName, descriptor, signature, exceptions);
+            }
         }
     }
 
@@ -45,7 +78,7 @@ public class ConfigurationTests {
 
     // Makes sure that c.addComment is not called in any config init functions.
     @Test
-    public void noAddCommentInConfigInit() {
-
+    public void noAddCommentInConfigInit() throws IOException {
+        TestUtils.test();
     }
 }

--- a/NachoSpigot-Server/src/test/java/me/elier/nachospigot/config/ConfigurationTests.java
+++ b/NachoSpigot-Server/src/test/java/me/elier/nachospigot/config/ConfigurationTests.java
@@ -9,6 +9,11 @@ import java.io.FileWriter;
 import java.io.IOException;
 
 public class ConfigurationTests {
+    private class TestUtils {
+        public void containsMethodInvocation() {
+
+        }
+    }
 
     @Test
     public void migrateFullConfig() {
@@ -36,5 +41,11 @@ public class ConfigurationTests {
     @Test
     public void loadConfig() {
         NachoConfig.init(new File("nacho.yml"));
+    }
+
+    // Makes sure that c.addComment is not called in any config init functions.
+    @Test
+    public void noAddCommentInConfigInit() {
+
     }
 }


### PR DESCRIPTION
# Description

Comments now show up in the config and a new way of comments is used and enforced during tests.
If the old way of comments is still used, tests will fail and it will tell you what is wrong.
They must now be specified in the `loadComments` method.

Thanks, @Elierrr for fixing it!

# How has this been tested?

Tested locally, comments work.
Enforcing also works, tests fail if the old method is used anywhere.

# Checklist:

- [x] I have reviewed my code thoroughly.
- [x] I have tested my code.
- [x] My changes generate no new warnings
