### PR TITLE
Add notice to Citizens patch and remove ProtocolLib patch

### DIFF
--- a/.github/workflows/build-nachospigot.yml
+++ b/.github/workflows/build-nachospigot.yml
@@ -1,7 +1,6 @@
 name: NachoSpigot Build
 
-on:
-  push:
+on: [push]
 
 jobs:
   build:

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[skip]')"
+    if: ${{ !contains(github.event.head_commit.message, '[skip]') || github.repository != github.event.pull_request.head.repo.full_name}}
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 15

--- a/NachoSpigot-Server/src/main/java/me/elier/nachospigot/config/NachoConfig.java
+++ b/NachoSpigot-Server/src/main/java/me/elier/nachospigot/config/NachoConfig.java
@@ -111,7 +111,6 @@ public class NachoConfig {
         c.addComment("settings.commands.enable-plugins-command", "Toggles the /plugins command");
         c.addComment("settings.commands.enable-reload-command", "Toggles the /reload command");
         c.addComment("settings.fast-operators", "Enables Fast Operators, which uses a faster method for managing operators");
-        c.addComment("settings.patch-protocollib", "Enables the ProtocolLib runtime patch (not required on ProtocolLib version 4.7+)");
         c.addComment("settings.stop-notify-bungee", "Disables the firewall check when running BungeeCord");
         c.addComment("settings.anti-malware", "Enables the built-in anti malware feature");
         c.addComment("settings.kick-on-illegal-behavior", "Kicks players if they try to do an illegal action (e.g. using a creative mode action while not in creative mode.)");
@@ -223,11 +222,6 @@ public class NachoConfig {
 
     private static void useFastOperators() {
         useFastOperators = getBoolean("settings.fast-operators", false);
-    }
-    public static boolean patchProtocolLib;
-
-    private static void patchProtocolLib() {
-        patchProtocolLib = getBoolean("settings.patch-protocollib", true);
     }
     public static boolean stopNotifyBungee;
 

--- a/NachoSpigot-Server/src/main/java/me/elier/util/StringUtils.java
+++ b/NachoSpigot-Server/src/main/java/me/elier/util/StringUtils.java
@@ -1,0 +1,14 @@
+package me.elier.util;
+
+public class StringUtils {
+    public static String repeat(String string, int count) {
+        return new String(new char[count]).replace("\0", string);
+    }
+
+    public static int getIndentation(String s){
+        if(!s.startsWith(" ")) return 0;
+        int i = 0;
+        while((s = s.replaceFirst(" ", "")).startsWith(" ")) i++;
+        return i+1;
+    }
+}

--- a/NachoSpigot-Server/src/main/java/me/elier/util/Utils.java
+++ b/NachoSpigot-Server/src/main/java/me/elier/util/Utils.java
@@ -1,7 +1,0 @@
-package me.elier.util;
-
-public class Utils {
-    public static String repeat(String string, int count) {
-        return new String(new char[count]).replace("\0", string);
-    }
-}

--- a/NachoSpigot-Server/src/main/java/me/elier/util/minecraft/PluginUtils.java
+++ b/NachoSpigot-Server/src/main/java/me/elier/util/minecraft/PluginUtils.java
@@ -5,7 +5,7 @@ import org.bukkit.plugin.Plugin;
 public class PluginUtils {
 
     public static int getCitizensBuild(Plugin plugin) {
-       return Integer.parseInt(plugin.getDescription().getVersion().split("\\(build")[1].trim().replace(")", ""));
+       return Integer.parseInt(plugin.getDescription().getVersion().split("\\(build ")[1].replace(")", ""));
     }
 
 }

--- a/NachoSpigot-Server/src/main/java/me/elier/util/minecraft/PluginUtils.java
+++ b/NachoSpigot-Server/src/main/java/me/elier/util/minecraft/PluginUtils.java
@@ -1,0 +1,11 @@
+package me.elier.util.minecraft;
+
+import org.bukkit.plugin.Plugin;
+
+public class PluginUtils {
+
+    public static int getCitizensBuild(Plugin plugin) {
+       return Integer.parseInt(plugin.getDescription().getVersion().split("\\(build")[1].trim().replace(")", ""));
+    }
+
+}

--- a/NachoSpigot-Server/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+++ b/NachoSpigot-Server/src/main/java/org/bukkit/craftbukkit/CraftServer.java
@@ -328,7 +328,7 @@ public final class CraftServer implements Server {
                             } else {
                                 boolean val = RuntimePatches.applyCitizensPatch(plugin).join();
                                 if (val) {
-                                    Logger.getLogger(CraftServer.class.getName()).log(Level.INFO, "Callback returned a good state, Citizens patch was successful and Citizens is now loading.");
+                                    Logger.getLogger(CraftServer.class.getName()).log(Level.INFO, "Citizens patch was successful and Citizens is now loading.");
                                 } else {
                                     Logger.getLogger(CraftServer.class.getName()).log(Level.SEVERE, "An error occurred trying to patch Citizens, the plugin will not work as expected!");
                                     Thread.sleep(3000);

--- a/NachoSpigot-Server/src/main/java/org/sugarcanemc/sugarcane/util/yaml/YamlCommenter.java
+++ b/NachoSpigot-Server/src/main/java/org/sugarcanemc/sugarcane/util/yaml/YamlCommenter.java
@@ -8,7 +8,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
-import me.elier.util.Utils;
+import me.elier.util.StringUtils;
 
 public class YamlCommenter {
     private final HashMap<String, String> comments = new HashMap<>();
@@ -57,8 +57,8 @@ public class YamlCommenter {
                 ));
             }
 
-            String prefix = Utils.repeat(" ", getIndentation(lines.get(line))) + "# ";
-            boolean noNewline = getIndentation(lines.get(line)) > getIndentation(lines.get(line - 1));
+            String prefix = StringUtils.repeat(" ", StringUtils.getIndentation(lines.get(line))) + "# ";
+            boolean noNewline = StringUtils.getIndentation(lines.get(line)) > StringUtils.getIndentation(lines.get(line - 1));
             if (line >= 0)
                 lines.add(line, (noNewline ?"":"\n") + prefix + _comment.getValue().replace("\n", "\n" + prefix));
             else System.out.printf("Failed to find key %s in %s!", _comment.getKey(), file);
@@ -67,12 +67,5 @@ public class YamlCommenter {
         FileWriter fw = new FileWriter(file);
         fw.write(text);
         fw.close();
-    }
-
-    private int getIndentation(String s){
-        if(!s.startsWith(" ")) return 0;
-        int i = 0;
-        while((s = s.replaceFirst(" ", "")).startsWith(" ")) i++;
-        return i+1;
     }
 }

--- a/NachoSpigot-Server/src/main/java/xyz/sculas/nacho/patches/RuntimePatches.java
+++ b/NachoSpigot-Server/src/main/java/xyz/sculas/nacho/patches/RuntimePatches.java
@@ -68,51 +68,6 @@ public class RuntimePatches
         }
     }
 
-    public static CompletableFuture<Boolean> applyProtocolLibPatch(Plugin plugin) {
-        return CompletableFuture.supplyAsync(() -> {
-            try {
-                logger.info("Patching ProtocolLib, please wait.");
-
-                try {
-                    String[] tmp = plugin.getDescription().getVersion().split("\\.");
-                    if (Integer.parseInt(tmp[0]) <= 4 && Integer.parseInt(tmp[1]) <= 6) {
-                        logger.warning(
-                                "Please update to ProtocolLib version 4.7.0 or higher!\n" +
-                                        "In version 4.6.0 and lower, we have to do a nasty fix to make it work.\n" +
-                                        "So.. once again, please update!\n" +
-                                        "You can update with this link: " +
-                                        "https://github.com/dmulloy2/ProtocolLib/releases/latest\n" +
-                                        "Sleeping for 10s so this message can be read."
-                        );
-                        Thread.sleep(10000);
-                    } else {
-                        logger.info("It seems that you are using ProtocolLib version 4.7 or higher, which is supported!");
-                        logger.info("No need to patch ProtocolLib, skipping.");
-                        return true;
-                    }
-                } catch (Exception ignored) {}
-
-                ClassPool pool = ClassPool.getDefault();
-                pool.insertClassPath(new LoaderClassPath(plugin.getClass().getClassLoader()));
-
-                CtClass defaultProtocolInjector = pool.get("com.comphenix.protocol.injector.netty.ProtocolInjector$1");
-                if (defaultProtocolInjector.isFrozen()) defaultProtocolInjector.defrost();
-
-
-                CtClass clazz = pool.makeClass(CraftServer.class.getClassLoader().getResourceAsStream("protpatch.class"));
-                clazz.replaceClassName(clazz.getName(), "com.comphenix.protocol.injector.netty.ProtocolInjector$1");
-                clazz.toClass(plugin.getClass().getClassLoader(), plugin.getClass().getProtectionDomain());
-
-                logger.info("Successfully patched ProtocolLib!");
-                return true;
-            } catch (Exception e) {
-                logger.warning("Could not patch ProtocolLib.");
-                e.printStackTrace();
-            }
-            return false;
-        });
-    }
-
     public static CompletableFuture<Boolean> applyCitizensPatch(Plugin plugin) {
         return CompletableFuture.supplyAsync(() -> {
             try {

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 NachoSpigot offers a number of enhancements to performance as well as bug fixes such as a built-in anti-crash system and being able to perform well with a large number of players.
 
 ## Current State
-Java 15 is now natively supported, and [ProtocolLib](https://github.com/dmulloy2/ProtocolLib), [ViaVersion](https://github.com/ViaVersion/ViaVersion), and [Citizens2](https://github.com/CitizensDev/Citizens2) are patched at runtime to work with Nacho's modifications.
+Java 15 is now natively supported, and [ViaVersion](https://github.com/ViaVersion/ViaVersion) is patched at runtime to work with Nacho's modifications.
 
 Nacho can now be used in production environments with some degree of stability.
 
@@ -110,8 +110,8 @@ See: [Contributors Page](https://github.com/CobbleSword/NachoSpigot/graphs/contr
 [Nacho-0030] add a ChunkPreLoadEvent
 [Nacho-0031] remove unused vars
 [Nacho-0033] Faster Operator search method
-[Nacho-0049] Don't allocate empty int arrays for particles
-[Nacho-0050] Option to disable Enchantment table ticking
+[Nacho-0048] Don't allocate empty int arrays for particles
+[Nacho-0049] Option to disable Enchantment table ticking
 
 <--> by Sculas
 [Nacho-0034] Remove Java 8 message from TacoSpigot which made it so you couldn't run Java 8 or higher
@@ -122,14 +122,13 @@ See: [Contributors Page](https://github.com/CobbleSword/NachoSpigot/graphs/contr
 [Nacho-0040] Change deprecated Netty parameter in ResourceLeakDetector
 [Nacho-0041] Fix block placement
 [Nacho-0042] Remove Spigot Watchdog
-[Nacho-0043] Fix ProtocolLib
-[Nacho-0044] Fix Citizens
-[Nacho-0045] Async obfuscation
-[Nacho-0046] Add Player#jump and Player#sendActionBar
-[Nacho-0047] Little anti-malware
-[Nacho-0048] Little anti-crash
-[Nacho-0051] Custom knockback
-[Nacho-0052] Rework ServerConnection and MinecraftPipeline (credits to Minestom)
+[Nacho-0043] Fix Citizens
+[Nacho-0044] Async obfuscation
+[Nacho-0045] Add Player#jump and Player#sendActionBar
+[Nacho-0046] Little anti-malware
+[Nacho-0047] Little anti-crash
+[Nacho-0050] Custom knockback
+[Nacho-0051] Rework ServerConnection and MinecraftPipeline (credits to Minestom)
 
 [Yatopia-0030] Don't save Fireworks and Arrows by tr7zw (Arrows and firework Entities, eg stuck arrows in the ground)
 [Yatopia-0047] Smarter statistics ticking

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 NachoSpigot offers a number of enhancements to performance as well as bug fixes such as a built-in anti-crash system and being able to perform well with a large number of players.
 
 ## Current State
-Java 15 is now natively supported, and [ViaVersion](https://github.com/ViaVersion/ViaVersion) is patched at runtime to work with Nacho's modifications.
+Java 15 is natively supported and also the recommended version to use.
 
 Nacho can now be used in production environments with some degree of stability.
 


### PR DESCRIPTION
# Description

Removes ProtocolLib patch, adds a notice to Citizens patch, and updates PR workflow to only run when the source branch is on a fork.

# Checklist:

- [x] I have reviewed my code thoroughly.
- [x] I have tested my code.
- [x] My changes generate no new warnings
