### PR TITLE
Ender Pearl Spawn Patch

### DIFF
--- a/NachoSpigot-Server/src/main/java/dev/cobblesword/nachospigot/Nacho.java
+++ b/NachoSpigot-Server/src/main/java/dev/cobblesword/nachospigot/Nacho.java
@@ -5,7 +5,6 @@ import dev.cobblesword.nachospigot.knockback.KnockbackConfig;
 import me.elier.nachospigot.config.NachoConfig;
 import xyz.sculas.nacho.anticrash.AntiCrash;
 import xyz.sculas.nacho.async.AsyncExplosions;
-import xyz.sculas.nacho.patches.RuntimePatches;
 import dev.cobblesword.nachospigot.protocol.PacketListener;
 import dev.cobblesword.nachospigot.protocol.MovementListener;
 import net.minecraft.server.MinecraftServer;

--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/EntityProjectile.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/EntityProjectile.java
@@ -30,9 +30,9 @@ public abstract class EntityProjectile extends Entity implements IProjectile {
     public EntityProjectile(World world, EntityLiving entityliving) {
         super(world);
         this.shooter = entityliving;
-        this.projectileSource = (org.bukkit.entity.LivingEntity) entityliving.getBukkitEntity(); // CraftBukkit
+        this.projectileSource = entityliving == null ? null : (org.bukkit.entity.LivingEntity) entityliving.getBukkitEntity(); // CraftBukkit
         this.setSize(0.25F, 0.25F);
-        this.setPositionRotation(entityliving.locX, entityliving.locY + (double) entityliving.getHeadHeight(), entityliving.locZ, entityliving.yaw, entityliving.pitch);
+        this.setPositionRotation(entityliving == null ? 0 : entityliving.locX, entityliving == null ? 0 : entityliving.locY + (double) entityliving.getHeadHeight(), entityliving == null ? 0 : entityliving.locZ, entityliving == null ? 0 : entityliving.yaw, entityliving == null ? 0 : entityliving.pitch);
         this.locX -= (double) (MathHelper.cos(this.yaw / 180.0F * 3.1415927F) * 0.16F);
         this.locY -= 0.10000000149011612D;
         this.locZ -= (double) (MathHelper.sin(this.yaw / 180.0F * 3.1415927F) * 0.16F);

--- a/NachoSpigot-Server/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+++ b/NachoSpigot-Server/src/main/java/org/bukkit/craftbukkit/CraftServer.java
@@ -28,7 +28,6 @@ import org.apache.commons.lang3.JavaVersion;
 import org.apache.commons.lang3.SystemUtils;
 import org.bukkit.craftbukkit.inventory.*;
 import xyz.sculas.nacho.malware.AntiMalware;
-import xyz.sculas.nacho.patches.RuntimePatches;
 import net.minecraft.server.*;
 
 import org.bukkit.BanList;


### PR DESCRIPTION
# Description

Please provide a detailed description of the changes you have made.

- When attempted to spawn an Ender Pearl with the ``World#spawnEntity`` method, it throwed an ``NullPointerException`` exception. I solved it by adding a few null checks to the EntityProjectile class and sat the position rotation parameters to 0 when said entity is null (though it'd be better than ignoring it entirely)
- Removed two imports that prevented the server jar from compiling properly (FIXED IN #272)

# How has this been tested?

How have you tested the changes you have made?
- By re-attempting to spawn the Ender Pearl with the mentioned method

# Checklist:

- [x] I have reviewed my code thoroughly.
- [x] I have tested my code.
- [x] My changes generate no new warnings
