### PR TITLE
Remove explosion-protected-regions

### DIFF
--- a/NachoSpigot-Server/src/main/java/me/elier/nachospigot/config/NachoConfig.java
+++ b/NachoSpigot-Server/src/main/java/me/elier/nachospigot/config/NachoConfig.java
@@ -73,7 +73,6 @@ public class NachoConfig {
         set("world-settings.default.tick-enchantment-tables", nachoJson.shouldTickEnchantmentTables);
         set("settings.panda-wire", nachoJson.usePandaWire);
         set("world-settings.default.explosions.constant-radius", nachoJson.constantExplosions);
-        set("world-settings.default.explosions.explode-protected-regions", nachoJson.explosionProtectedRegions);
         set("settings.event.fire-entity-explode-event", nachoJson.fireEntityExplodeEvent);
         set("world-settings.default.explosions.reduced-density-rays", nachoJson.reducedDensityRays);
         set("settings.brand-name", nachoJson.serverBrandName);

--- a/NachoSpigot-Server/src/main/java/me/elier/nachospigot/config/NachoWorldConfig.java
+++ b/NachoSpigot-Server/src/main/java/me/elier/nachospigot/config/NachoWorldConfig.java
@@ -5,6 +5,7 @@ import org.bukkit.configuration.file.YamlConfiguration;
 
 import java.util.List;
 
+@SuppressWarnings("unused")
 public class NachoWorldConfig {
 
     private final String worldName;
@@ -81,7 +82,6 @@ public class NachoWorldConfig {
         addComment("entity.endermite-spawning", "Enables endermite spawning.");
         addComment("infinite-water-sources", "Enables infinite water sources");
         addComment("explosions.constant-radius", "Changes the radius of explosions to be constant.");
-        addComment("explosions.explode-protected-regions", "Toggles whether explosions should explode protected regions");
         addComment("explosions.reduced-density-rays", "Toggles whether the server should use reduced rays when calculating density");
         addComment("tick-enchantment-tables", "Toggles whether enchantment tables should be ticked");
     }
@@ -137,12 +137,10 @@ public class NachoWorldConfig {
     }
 
     public boolean constantExplosions;
-    public boolean explosionProtectedRegions;
     public boolean reducedDensityRays;
 
     private void explosions() {
         constantExplosions = getBoolean("explosions.constant-radius", false);
-        explosionProtectedRegions = getBoolean("explosions.explode-protected-regions", true);
         reducedDensityRays = getBoolean("explosions.reduced-density-rays", true);
     }
 

--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/Explosion.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/Explosion.java
@@ -188,20 +188,20 @@ public class Explosion {
                 }
             }
 
-            boolean cancelled;
-            List<org.bukkit.block.Block> bukkitBlocks;
-            float yield;
+            boolean cancelled = false;
+            List<org.bukkit.block.Block> bukkitBlocks = blockList;
+            float yield = 0.3F; // default
 
             if (explode != null) {
                 if (NachoConfig.fireEntityExplodeEvent) {
-                    EntityExplodeEvent event = new EntityExplodeEvent(explode, location, blockList, 0.3F);
+                    EntityExplodeEvent event = new EntityExplodeEvent(explode, location, blockList, yield);
                     this.world.getServer().getPluginManager().callEvent(event);
                     cancelled = event.isCancelled();
                     bukkitBlocks = event.blockList();
                     yield = event.getYield();
                 }
             } else {
-                BlockExplodeEvent event = new BlockExplodeEvent(location.getBlock(), blockList, 0.3F);
+                BlockExplodeEvent event = new BlockExplodeEvent(location.getBlock(), blockList, yield);
                 this.world.getServer().getPluginManager().callEvent(event);
                 cancelled = event.isCancelled();
                 bukkitBlocks = event.blockList();

--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/Explosion.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/Explosion.java
@@ -3,21 +3,22 @@ package net.minecraft.server;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
-import java.util.*;
-import java.util.concurrent.CompletableFuture;
-
-// CraftBukkit start
+// Nacho start
 import dev.cobblesword.nachospigot.commons.Constants;
 import dev.cobblesword.nachospigot.commons.minecraft.MCUtils;
 import me.elier.nachospigot.config.NachoConfig;
 import net.jafama.FastMath;
-
-import org.bukkit.craftbukkit.event.CraftEventFactory;
-import org.bukkit.event.entity.EntityExplodeEvent;
+// Nacho end
+// CraftBukkit start
 import org.bukkit.Location;
+import org.bukkit.craftbukkit.event.CraftEventFactory;
 import org.bukkit.event.block.BlockExplodeEvent;
+import org.bukkit.event.entity.EntityExplodeEvent;
 import xyz.sculas.nacho.async.AsyncExplosions;
 // CraftBukkit end
+
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
 
 public class Explosion {
 
@@ -63,28 +64,10 @@ public class Explosion {
         Block b = chunk.getBlockData(pos).getBlock(); // TacoSpigot - get block of the explosion
 
         if (!this.world.tacoSpigotConfig.optimizeLiquidExplosions || !b.getMaterial().isLiquid()) { // TacoSpigot - skip calculating what blocks to blow up in water/lava
-            boolean protection = false;
-            if ((NachoConfig.fireEntityExplodeEvent || world.nachoSpigotConfig.explosionProtectedRegions) && source != null) {
-                Location location = new Location(world.getWorld(), posX, posY, posZ);
-
-                List<org.bukkit.block.Block> list = new java.util.ArrayList<>(1);
-                int x = org.bukkit.util.NumberConversions.floor(posX);
-                int y = org.bukkit.util.NumberConversions.floor(posY);
-                int z = org.bukkit.util.NumberConversions.floor(posZ);
-                list.add(chunk.bukkitChunk.getBlock(x, y, z));
-
-                EntityExplodeEvent event = new EntityExplodeEvent(source.getBukkitEntity(), location, list, 0.3F);
-                world.getServer().getPluginManager().callEvent(event);
-                if (event.isCancelled() || event.blockList().isEmpty()) {
-                    protection = true;
-                }
-            }
-            if (!protection) {
-                it.unimi.dsi.fastutil.longs.LongSet set = new it.unimi.dsi.fastutil.longs.LongOpenHashSet();
-                searchForBlocks(set, chunk);
-                for (it.unimi.dsi.fastutil.longs.LongIterator iterator = set.iterator(); iterator.hasNext(); ) {
-                    this.blocks.add(BlockPosition.fromLong(iterator.nextLong()));
-                }
+            it.unimi.dsi.fastutil.longs.LongSet set = new it.unimi.dsi.fastutil.longs.LongOpenHashSet();
+            searchForBlocks(set, chunk);
+            for (it.unimi.dsi.fastutil.longs.LongIterator iterator = set.iterator(); iterator.hasNext(); ) {
+                this.blocks.add(BlockPosition.fromLong(iterator.nextLong()));
             }
         }
 
@@ -198,7 +181,7 @@ public class Explosion {
 
             List<org.bukkit.block.Block> blockList = Lists.newArrayList();
             for (int i1 = this.blocks.size() - 1; i1 >= 0; i1--) {
-                BlockPosition cpos = (BlockPosition) this.blocks.get(i1);
+                BlockPosition cpos = this.blocks.get(i1);
                 org.bukkit.block.Block bblock = bworld.getBlockAt(cpos.getX(), cpos.getY(), cpos.getZ());
                 if (bblock.getType() != org.bukkit.Material.AIR) {
                     blockList.add(bblock);
@@ -211,7 +194,9 @@ public class Explosion {
 
             if (explode != null) {
                 EntityExplodeEvent event = new EntityExplodeEvent(explode, location, blockList, 0.3F);
-                this.world.getServer().getPluginManager().callEvent(event);
+                if (NachoConfig.fireEntityExplodeEvent) {
+                    this.world.getServer().getPluginManager().callEvent(event);
+                }
                 cancelled = event.isCancelled();
                 bukkitBlocks = event.blockList();
                 yield = event.getYield();
@@ -332,7 +317,7 @@ public class Explosion {
                         d0 = (d0 / d3) * 0.30000001192092896D;
                         d1 = (d1 / d3) * 0.30000001192092896D;
                         d2 = (d2 / d3) * 0.30000001192092896D;
-                        VECTORS.add(new double[] {d0, d1, d2});
+                        VECTORS.add(new double[]{d0, d1, d2});
                     }
                 }
             }

--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/Explosion.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/Explosion.java
@@ -193,13 +193,13 @@ public class Explosion {
             float yield;
 
             if (explode != null) {
-                EntityExplodeEvent event = new EntityExplodeEvent(explode, location, blockList, 0.3F);
                 if (NachoConfig.fireEntityExplodeEvent) {
+                    EntityExplodeEvent event = new EntityExplodeEvent(explode, location, blockList, 0.3F);
                     this.world.getServer().getPluginManager().callEvent(event);
+                    cancelled = event.isCancelled();
+                    bukkitBlocks = event.blockList();
+                    yield = event.getYield();
                 }
-                cancelled = event.isCancelled();
-                bukkitBlocks = event.blockList();
-                yield = event.getYield();
             } else {
                 BlockExplodeEvent event = new BlockExplodeEvent(location.getBlock(), blockList, 0.3F);
                 this.world.getServer().getPluginManager().callEvent(event);


### PR DESCRIPTION
# Description

Removes the configuration option "explosion-proteccted-regions"

Fixes #230
Fixes #302
Closes #303 

# Additional Comments

I'm not exactly sure what this is for however it doesn't seem to be needed.

# Checklist:

- [x] I have reviewed my code thoroughly.
- [x] I have tested my code.
- [x] My changes generate no new warnings
