### PR TITLE
Remove player-time-statistics-interval

### DIFF
--- a/NachoSpigot-Server/src/main/java/me/elier/nachospigot/config/NachoConfig.java
+++ b/NachoSpigot-Server/src/main/java/me/elier/nachospigot/config/NachoConfig.java
@@ -76,7 +76,6 @@ public class NachoConfig {
         set("world-settings.default.explosions.explode-protected-regions", nachoJson.explosionProtectedRegions);
         set("settings.event.fire-entity-explode-event", nachoJson.fireEntityExplodeEvent);
         set("world-settings.default.explosions.reduced-density-rays", nachoJson.reducedDensityRays);
-        set("settings.player-time-statistics-interval", nachoJson.playerTimeStatisticsInterval);
         set("settings.brand-name", nachoJson.serverBrandName);
         set("settings.stop-decoding-itemstack-on-place", nachoJson.stopDecodingItemStackOnPlace);
         set("settings.anti-crash", nachoJson.enableAntiCrash);
@@ -118,7 +117,6 @@ public class NachoConfig {
         c.addComment("settings.event.fire-entity-explode-event", "Toggles the entity explode event");
         c.addComment("settings.event.fire-player-move-event", "Toggles the player move event");
         c.addComment("settings.event.fire-leaf-decay-event", "Toggles the leaf decay event");
-        c.addComment("settings.player-time-statistics-interval", "Changes when statistics are ticked (e.g. 20 would be every 20th tick)");
         c.addComment("settings.brand-name", "Changes the brand name of the server.\nThis will show in statistics, server lists, client crashes,\n and in the client debug screen. (accessed by pressing F3)");
         c.addComment("settings.stop-decoding-itemstack-on-place", "Disables decoding itemstacks when not needed");
         c.addComment("settings.anti-crash", "Kicks players if they try to do an action that would/might crash the server");
@@ -254,12 +252,6 @@ public class NachoConfig {
         fireEntityExplodeEvent = getBoolean("settings.event.fire-entity-explode-event", true);
         firePlayerMoveEvent = getBoolean("settings.event.fire-player-move-event", true);
         leavesDecayEvent = getBoolean("settings.event.fire-leaf-decay-event", true);
-    }
-
-    public static int playerTimeStatisticsInterval;
-
-    private static void playerTimeStatisticsInterval() {
-        playerTimeStatisticsInterval = getInt("settings.player-time-statistics-interval", 20);
     }
 
     public static String serverBrandName;

--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/EntityHuman.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/EntityHuman.java
@@ -1341,7 +1341,7 @@ public abstract class EntityHuman extends EntityLiving {
     }
 
     public void b(Statistic statistic) {
-        this.a(statistic, NachoConfig.playerTimeStatisticsInterval); // Nacho / Yatopia - or do it like this :shrug:
+        this.a(statistic, 1);
     }
 
     public void a(Statistic statistic, int i) {}


### PR DESCRIPTION
# Description

Removes player-time-statistics-interval

Fixes #295 

# How has this been tested?

By removing the config and testing #295 

# Additional Comments

This config doesn't improve anything at all and just duplicates statistics

# Checklist:

- [x] I have reviewed my code thoroughly.
- [x] I have tested my code.
- [x] My changes generate no new warnings
