### PR TITLE
Re-add CraftBukkit's deprecation mappings

### DIFF
--- a/NachoSpigot-Server/reobf-mappings.csrg
+++ b/NachoSpigot-Server/reobf-mappings.csrg
@@ -50,3 +50,25 @@ net/minecraft/server/v1_8_R3/MinecraftServer setPlayerList (Lnet/minecraft/serve
 net/minecraft/server/v1_8_R3/MinecraftServer port u
 net/minecraft/server/v1_8_R3/MinecraftServer getPort ()I R
 net/minecraft/server/v1_8_R3/MinecraftServer playerList v
+
+# CraftBukkit's deprecation mappings
+org/bukkit/Bukkit _INVALID_getOnlinePlayers ()[Lorg/bukkit/entity/Player; getOnlinePlayers
+org/bukkit/Server _INVALID_getOnlinePlayers ()[Lorg/bukkit/entity/Player; getOnlinePlayers
+org/bukkit/entity/Damageable _INVALID_damage (I)V damage
+org/bukkit/entity/Damageable _INVALID_damage (ILorg/bukkit/entity/Entity;)V damage
+org/bukkit/entity/Damageable _INVALID_getHealth ()I getHealth
+org/bukkit/entity/Damageable _INVALID_getMaxHealth ()I getMaxHealth
+org/bukkit/entity/Damageable _INVALID_setHealth (I)V setHealth
+org/bukkit/entity/Damageable _INVALID_setMaxHealth (I)V setMaxHealth
+org/bukkit/entity/LivingEntity _INVALID_getLastDamage ()I getLastDamage
+org/bukkit/entity/LivingEntity _INVALID_setLastDamage (I)V setLastDamage
+org/bukkit/entity/Minecart _INVALID_getDamage ()I getDamage
+org/bukkit/entity/Minecart _INVALID_setDamage (I)V setDamage
+org/bukkit/entity/Projectile _INVALID_getShooter ()Lorg/bukkit/entity/LivingEntity; getShooter
+org/bukkit/entity/Projectile _INVALID_setShooter (Lorg/bukkit/entity/LivingEntity;)V setShooter
+org/bukkit/event/entity/EntityDamageEvent _INVALID_getDamage ()I getDamage
+org/bukkit/event/entity/EntityDamageEvent _INVALID_setDamage (I)V setDamage
+org/bukkit/event/entity/EntityRegainHealthEvent _INVALID_getAmount ()I getAmount
+org/bukkit/event/entity/EntityRegainHealthEvent _INVALID_setAmount (I)V setAmount
+org/bukkit/event/vehicle/VehicleDamageEvent _INVALID_getDamage ()I getDamage
+org/bukkit/event/vehicle/VehicleDamageEvent _INVALID_setDamage (I)V setDamage


### PR DESCRIPTION
# Description

Re-adds CraftBukkit's deprecation mappings

# Additional comments

I haven't tested this, but it's exactly the same from CraftBukkit's deprecation mappings so it should work just as fine. I also haven't added the deprecation-mappings.at file however it doesn't seem to be needed since it just makes it synthetic and CraftBukkit also removes it in 1.9 

# Checklist:

- [x] I have reviewed my code thoroughly.
- [ ] I have tested my code.
- [x] My changes generate no new warnings
