### PR TITLE
Arrow pickup sound fix

### DIFF
--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/EntityArrow.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/EntityArrow.java
@@ -452,7 +452,7 @@ public class EntityArrow extends Entity implements IProjectile {
             }
 
             if (flag) {
-                world.makeSound(entityhuman,"random.pop", 0.2F, ((this.random.nextFloat() - this.random.nextFloat()) * 0.7F + 1.0F) * 2.0F);
+                this.makeSound("random.pop", 0.2F, ((this.random.nextFloat() - this.random.nextFloat()) * 0.7F + 1.0F) * 2.0F);
                 entityhuman.receive(this, 1);
                 this.die();
             }

--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/EntityArrow.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/EntityArrow.java
@@ -452,7 +452,7 @@ public class EntityArrow extends Entity implements IProjectile {
             }
 
             if (flag) {
-                world.makeSound(this.shooter,"random.pop", 0.2F, ((this.random.nextFloat() - this.random.nextFloat()) * 0.7F + 1.0F) * 2.0F);
+                world.makeSound(entityhuman,"random.pop", 0.2F, ((this.random.nextFloat() - this.random.nextFloat()) * 0.7F + 1.0F) * 2.0F);
                 entityhuman.receive(this, 1);
                 this.die();
             }


### PR DESCRIPTION
# Description
When the shooter shot an arrow and another player picked up the arrow, the shooter heard the pickup sound (random.pop) .
I changed it a little so the player who picks up the arrow hears the sound, and not the shooter.

# How has this been tested?
I tested this on my server with few other players.

# Checklist:

- [✓] I have reviewed my code thoroughly.
- [✓] I have tested my code.
- [✓] My changes generate no new warnings
