### PR TITLE
Re-add old knockback method for plugins

### DIFF
--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/EntityLiving.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/EntityLiving.java
@@ -884,6 +884,10 @@ public abstract class EntityLiving extends Entity {
     }
 
     protected void dropEquipment(boolean flag, int i) {}
+    
+    public void a(Entity entity, float f, double d0, double d1) {
+          a(x, z, null);
+    }
 
     public void a(double x, double z, DamageSource source) {
         if (this.random.nextDouble() >= this.getAttributeInstance(GenericAttributes.c).getValue()) {

--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/EntityLiving.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/EntityLiving.java
@@ -886,7 +886,7 @@ public abstract class EntityLiving extends Entity {
     protected void dropEquipment(boolean flag, int i) {}
     
     public void a(Entity entity, float f, double d0, double d1) {
-          a(x, z, null);
+          a(d0, d1, null);
     }
 
     public void a(double x, double z, DamageSource source) {


### PR DESCRIPTION
# Description

Re-adds `a(Entity, float, double, double)` in EntityLiving for plugins to use.

# Checklist:

- [x] I have reviewed my code thoroughly.
- [ ] I have tested my code.
- [x] My changes generate no new warnings
