### PR TITLE
ChannelInitializeListenerHolder

### DIFF
--- a/NachoSpigot-API/pom.xml
+++ b/NachoSpigot-API/pom.xml
@@ -97,26 +97,8 @@
         <!-- https://mvnrepository.com/artifact/net.kyori/adventure-api -->
         <dependency>
             <groupId>net.kyori</groupId>
-            <artifactId>adventure-api</artifactId>
+            <artifactId>adventure-key</artifactId>
             <version>4.9.3</version>
-        </dependency>
-        <dependency>
-            <groupId>net.kyori</groupId>
-            <artifactId>adventure-text-serializer-gson</artifactId>
-            <version>4.9.3</version>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>net.kyori</groupId>
-            <artifactId>adventure-text-serializer-legacy</artifactId>
-            <version>4.9.3</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>net.kyori</groupId>
-            <artifactId>adventure-text-serializer-plain</artifactId>
-            <version>4.9.3</version>
-            <scope>runtime</scope>
         </dependency>
 
         <!-- testing -->

--- a/NachoSpigot-API/pom.xml
+++ b/NachoSpigot-API/pom.xml
@@ -88,6 +88,36 @@
             <artifactId>annotations</artifactId>
             <version>23.0.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.checkerframework</groupId>
+            <artifactId>checker-qual</artifactId>
+            <version>3.21.0</version>
+        </dependency>
+        <!-- Kyori api -->
+        <!-- https://mvnrepository.com/artifact/net.kyori/adventure-api -->
+        <dependency>
+            <groupId>net.kyori</groupId>
+            <artifactId>adventure-api</artifactId>
+            <version>4.9.3</version>
+        </dependency>
+        <dependency>
+            <groupId>net.kyori</groupId>
+            <artifactId>adventure-text-serializer-gson</artifactId>
+            <version>4.9.3</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.kyori</groupId>
+            <artifactId>adventure-text-serializer-legacy</artifactId>
+            <version>4.9.3</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.kyori</groupId>
+            <artifactId>adventure-text-serializer-plain</artifactId>
+            <version>4.9.3</version>
+            <scope>runtime</scope>
+        </dependency>
 
         <!-- testing -->
         <dependency>

--- a/NachoSpigot-Server/src/main/java/dev/cobblesword/nachospigot/protocol/MinecraftPipeline.java
+++ b/NachoSpigot-Server/src/main/java/dev/cobblesword/nachospigot/protocol/MinecraftPipeline.java
@@ -36,5 +36,6 @@ public class MinecraftPipeline extends ChannelInitializer<SocketChannel>
         this.serverConnection.pending.add(networkmanager); // Paper
         channel.pipeline().addLast("packet_handler", networkmanager);
         networkmanager.a(new HandshakeListener(this.serverConnection.server, networkmanager));
+        io.papermc.paper.network.ChannelInitializeListenerHolder.callListeners(channel); // Paper
     }
 }

--- a/NachoSpigot-Server/src/main/java/io/papermc/paper/network/ChannelInitializeListener.java
+++ b/NachoSpigot-Server/src/main/java/io/papermc/paper/network/ChannelInitializeListener.java
@@ -1,0 +1,16 @@
+package io.papermc.paper.network;
+
+import io.netty.channel.Channel;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/**
+ * Internal API to register channel initialization listeners.
+ * <p>
+ * This is not officially supported API and we make no guarantees to the existence or state of this interface.
+ */
+
+@FunctionalInterface
+public interface ChannelInitializeListener {
+
+    void afterInitChannel(@NonNull Channel channel);
+}

--- a/NachoSpigot-Server/src/main/java/io/papermc/paper/network/ChannelInitializeListenerHolder.java
+++ b/NachoSpigot-Server/src/main/java/io/papermc/paper/network/ChannelInitializeListenerHolder.java
@@ -1,0 +1,74 @@
+package io.papermc.paper.network;
+
+import io.netty.channel.Channel;
+import net.kyori.adventure.key.Key;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Internal API to register channel initialization listeners.
+ * <p>
+ * This is not officially supported API and we make no guarantees to the existence or state of this class.
+ */
+public final class ChannelInitializeListenerHolder {
+
+    private static final Map<Key, ChannelInitializeListener> LISTENERS = new HashMap<>();
+    private static final Map<Key, ChannelInitializeListener> IMMUTABLE_VIEW = Collections.unmodifiableMap(LISTENERS);
+
+    private ChannelInitializeListenerHolder() {
+    }
+
+    /**
+     * Registers whether an initialization listener is registered under the given key.
+     *
+     * @param key key
+     * @return whether an initialization listener is registered under the given key
+     */
+    public static boolean hasListener(@NonNull Key key) {
+        return LISTENERS.containsKey(key);
+    }
+
+    /**
+     * Registers a channel initialization listener called after ServerConnection is initialized.
+     *
+     * @param key      key
+     * @param listener initialization listeners
+     */
+    public static void addListener(@NonNull Key key, @NonNull ChannelInitializeListener listener) {
+        LISTENERS.put(key, listener);
+    }
+
+    /**
+     * Removes and returns an initialization listener registered by the given key if present.
+     *
+     * @param key key
+     * @return removed initialization listener if present
+     */
+    public static @Nullable ChannelInitializeListener removeListener(@NonNull Key key) {
+        return LISTENERS.remove(key);
+    }
+
+    /**
+     * Returns an immutable map of registered initialization listeners.
+     *
+     * @return immutable map of registered initialization listeners
+     */
+    public static @NonNull Map<Key, ChannelInitializeListener> getListeners() {
+        return IMMUTABLE_VIEW;
+    }
+
+    /**
+     * Calls the registered listeners with the given channel.
+     *
+     * @param channel channel
+     */
+    public static void callListeners(@NonNull Channel channel) {
+        for (ChannelInitializeListener listener : LISTENERS.values()) {
+            listener.afterInitChannel(channel);
+        }
+    }
+}

--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/PlayerConnection.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/PlayerConnection.java
@@ -271,19 +271,11 @@ public class PlayerConnection implements PacketListenerPlayIn, IUpdatePlayerList
         // CraftBukkit end
         final ChatComponentText chatcomponenttext = new ChatComponentText(s);
 
-        this.networkManager.a(new PacketPlayOutKickDisconnect(chatcomponenttext), new GenericFutureListener() {
-            public void operationComplete(Future future) throws Exception { // CraftBukkit - fix decompile error
-                PlayerConnection.this.networkManager.close(chatcomponenttext);
-            }
-        }, new GenericFutureListener[0]);
+        this.networkManager.a(new PacketPlayOutKickDisconnect(chatcomponenttext), future -> PlayerConnection.this.networkManager.close(chatcomponenttext));
         this.a(chatcomponenttext); // CraftBukkit - fire quit instantly
         this.networkManager.k();
         // CraftBukkit - Don't wait
-        this.minecraftServer.postToMainThread(new Runnable() {
-             public void run() {
-                 PlayerConnection.this.networkManager.l();
-            }
-        });
+        this.minecraftServer.postToMainThread(this.networkManager::l);
     }
 
     public void a(PacketPlayInSteerVehicle packetplayinsteervehicle) {


### PR DESCRIPTION
# Description

Add ChannelListener from paper-master, for better working of the viaversion

Fixes/Adds # (issue)

You can add channellister without reflection. 

# How has this been tested?

I have tested on own pc with viaversion, vulcan anticheat(packetevents) and I have added debug message to viaversion's injector. The console don't show error and these plugins work well.
