### PR TITLE
Fix plugins that use Citizens in their name

### DIFF
--- a/NachoSpigot-Server/src/main/java/dev/cobblesword/nachospigot/commons/minecraft/PluginUtils.java
+++ b/NachoSpigot-Server/src/main/java/dev/cobblesword/nachospigot/commons/minecraft/PluginUtils.java
@@ -7,6 +7,10 @@ import org.bukkit.plugin.Plugin;
  */
 public class PluginUtils {
     public static int getCitizensBuild(Plugin plugin) {
-        return Integer.parseInt(plugin.getDescription().getVersion().split("\\(build ")[1].replace(")", ""));
+        try {
+            return Integer.parseInt(plugin.getDescription().getVersion().split("\\(build ")[1].replace(")", ""));
+        } catch (Throwable ignored) {
+            return 2396;
+        }
     }
 }

--- a/NachoSpigot-Server/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+++ b/NachoSpigot-Server/src/main/java/org/bukkit/craftbukkit/CraftServer.java
@@ -312,7 +312,7 @@ public final class CraftServer implements Server {
                     // Nacho end
 
                     // Nacho start - Add notice for older Citizens versions
-                    else if(plugin.getDescription().getFullName().contains("Citizens")) {
+                    else if(plugin.getDescription().getFullName().equals("Citizens")) {
                         if(PluginUtils.getCitizensBuild(plugin) < 2396) {
                             logger.warning(
                                     "Please update to Citizens 2.0.28 #7 or higher!\n" +


### PR DESCRIPTION
# Description

Fixes issue with plugins that have “Citizens” in their name. (reported in the discord)

# Checklist:

- [x] I have reviewed my code thoroughly.
- [ ] I have tested my code.
- [x] My changes generate no new warnings
