### PR TITLE
fix sword blocking desync on player attack

### DIFF
--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/PlayerConnection.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/PlayerConnection.java
@@ -1554,6 +1554,11 @@ public class PlayerConnection implements PacketListenerPlayIn, IUpdatePlayerList
                     }
 
                     this.player.attack(entity);
+                    // wuangg start - fix sword blocking desync
+                    if (this.player.isBlocking()) {
+                    	this.player.bU();
+                    }
+                    // wuangg end
 
                     // CraftBukkit start
                     if (itemInHand != null && itemInHand.count <= -1) {


### PR DESCRIPTION
# Description

Fixes sword blocking desync on player attack when they're block-hitting, which can lead to negative effects to visual, gameplay and maybe anti-cheat.

_Fixes #347 _

# How has this been tested?

This code has been used in two production servers that I've been working on, no issues so far.

# Checklist:

- [x] I have reviewed my code thoroughly.
- [x] I have tested my code.
- [x] My changes generate no new warnings
