### PR TITLE
improve lag compensated hitreg

### DIFF
--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/Entity.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/Entity.java
@@ -1185,9 +1185,21 @@ public abstract class Entity implements ICommandListener {
 
     public double h(Entity entity) {
         if (NachoConfig.enableImprovedHitReg && entity instanceof EntityPlayer) {
-            Location loc = Nacho.get().getLagCompensator().getHistoryLocation(
+        	// wuangg start - fix npc can not be damaged properly
+            /* Location loc = Nacho.get().getLagCompensator().getHistoryLocation(
                     ((EntityPlayer) entity).getBukkitEntity()
-            );
+            );*/
+        	EntityPlayer player = (EntityPlayer) entity;
+        	
+        	Location loc;
+        	if (player.playerConnection.getClass().equals(PlayerConnection.class)) {
+                loc = Nacho.get().getLagCompensator().getHistoryLocation(
+                        player.getBukkitEntity()
+                );
+        	} else {
+        		loc = player.getBukkitEntity().getLocation();
+        	}
+        	// wuangg end
 
             double d0 = this.locX - loc.getX();
             double d1 = this.locY - loc.getY();

--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/EntityEnderPearl.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/EntityEnderPearl.java
@@ -106,7 +106,7 @@ public class EntityEnderPearl extends EntityProjectile {
                     }
                     // Nacho end
 
-                    Nacho.get().getLagCompensator().registerMovement(player, location);
+                    // Nacho.get().getLagCompensator().registerMovement(player, location); // wuangg - don't register movement if teleport event is cancelled
 
                     PlayerTeleportEvent teleEvent = new PlayerTeleportEvent(player, player.getLocation(), location, PlayerTeleportEvent.TeleportCause.ENDER_PEARL);
                     Bukkit.getPluginManager().callEvent(teleEvent);
@@ -125,6 +125,7 @@ public class EntityEnderPearl extends EntityProjectile {
                         }
 
                         entityplayer.playerConnection.teleport(teleEvent.getTo());
+                    	Nacho.get().getLagCompensator().registerMovement(player, teleEvent.getTo()); // wuangg - teleport destination can be changed during the event call
                         entityliving.fallDistance = 0.0F;
                         CraftEventFactory.entityDamage = this;
                         entityliving.damageEntity(DamageSource.FALL, 5.0F);

--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/PlayerConnection.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/PlayerConnection.java
@@ -377,7 +377,7 @@ public class PlayerConnection implements PacketListenerPlayIn, IUpdatePlayerList
                     this.lastYaw = to.getYaw();
                     this.lastPitch = to.getPitch();
 
-                    Nacho.get().getLagCompensator().registerMovement(player, to);
+                    // Nacho.get().getLagCompensator().registerMovement(player, to); // wuangg - don't register movement with destination if the event is cancelled
 
                     // Skip the first time we do this
                     if (NachoConfig.firePlayerMoveEvent) { // Spigot - don't skip any move events
@@ -387,7 +387,8 @@ public class PlayerConnection implements PacketListenerPlayIn, IUpdatePlayerList
 
                         // If the event is cancelled we move the player back to their old location.
                         if (event.isCancelled())
-                        {
+                        {	
+                        	Nacho.get().getLagCompensator().registerMovement(player, from); // wuangg
                             this.player.playerConnection.sendPacket(new PacketPlayOutPosition(from.getX(), from.getY(), from.getZ(), from.getYaw(), from.getPitch(), Collections.<PacketPlayOutPosition.EnumPlayerTeleportFlags>emptySet()));
                             return;
                         }
@@ -408,6 +409,8 @@ public class PlayerConnection implements PacketListenerPlayIn, IUpdatePlayerList
                             return;
                         }
                     }
+                    
+                    Nacho.get().getLagCompensator().registerMovement(player, to); // wuangg - moved down
                 }
 
                 if (this.checkMovement && !this.player.dead)
@@ -620,7 +623,7 @@ public class PlayerConnection implements PacketListenerPlayIn, IUpdatePlayerList
 
 
         Location to = new Location(this.getPlayer().getWorld(), x, y, z, yaw, pitch);
-        Nacho.get().getLagCompensator().registerMovement(player, to);
+        // Nacho.get().getLagCompensator().registerMovement(player, to); // wuangg - teleport destination can be changed during the event call
         PlayerTeleportEvent event = new PlayerTeleportEvent(player, from.clone(), to.clone(), PlayerTeleportEvent.TeleportCause.UNKNOWN);
         this.server.getPluginManager().callEvent(event);
 
@@ -634,6 +637,7 @@ public class PlayerConnection implements PacketListenerPlayIn, IUpdatePlayerList
             f1 = to.getPitch();
         }
 
+        Nacho.get().getLagCompensator().registerMovement(player, to); // wuangg - moved down
         this.internalTeleport(d0, d1, d2, f, f1, set);
     }
 

--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/PlayerList.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/PlayerList.java
@@ -576,7 +576,7 @@ public abstract class PlayerList {
 
             Player respawnPlayer = cserver.getPlayer(entityplayer1);
 
-            Nacho.get().getLagCompensator().registerMovement(respawnPlayer, location);
+            // Nacho.get().getLagCompensator().registerMovement(respawnPlayer, location); // wuangg - don't register movement if player is already disconnected
 
             PlayerRespawnEvent respawnEvent = new PlayerRespawnEvent(respawnPlayer, location, isBedSpawn);
             cserver.getPluginManager().callEvent(respawnEvent);
@@ -586,6 +586,7 @@ public abstract class PlayerList {
             }
             // Spigot End
 
+            Nacho.get().getLagCompensator().registerMovement(respawnPlayer, location); // wuangg - moved down
             location = respawnEvent.getRespawnLocation();
             entityplayer.reset();
         } else {

--- a/NachoSpigot-Server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+++ b/NachoSpigot-Server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
@@ -534,7 +534,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
         // To = Players new Location if Teleport is Successful
         Location to = location;
         // Create & Call the Teleport Event.
-        Nacho.get().getLagCompensator().registerMovement(this, to);
+        // Nacho.get().getLagCompensator().registerMovement(this, to); // wuangg - don't register movement if teleport event is cancelled
         PlayerTeleportEvent event = new PlayerTeleportEvent(this, from, to, cause);
         server.getPluginManager().callEvent(event);
 
@@ -542,6 +542,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
         if (event.isCancelled()) {
             return false;
         }
+        
+        Nacho.get().getLagCompensator().registerMovement(this, event.getTo()); // wuangg - teleport destination can be changed during the event call
 
         // If this player is riding another entity, we must dismount before teleporting.
         entity.mount(null);


### PR DESCRIPTION
# Description

Improves lag compensated hit registration, to make sure it is compatible with modification from Bukkit event calls when registering movement.

_Fixes #350_
`LagCompensator#registerMovement` _now is compatible with modification from Bukkit event calls (more detail in code comments).

# How has this been tested?

This PR should be tested more properly, even though #350 has been fixed by testing with latest version of Citizens2. I'm not sure if it should work with other plugins use Citizens2 as dependency.

# Checklist:

- [x] I have reviewed my code thoroughly.
- [x] I have tested my code.
- [x] My changes generate no new warnings
