### PR TITLE
Clear player lag compensator cache on disconnect

### DIFF
--- a/NachoSpigot-Server/src/main/java/dev/cobblesword/nachospigot/hitdetection/LagCompensator.java
+++ b/NachoSpigot-Server/src/main/java/dev/cobblesword/nachospigot/hitdetection/LagCompensator.java
@@ -76,4 +76,8 @@ public class LagCompensator {
         processPosition(to, player);
     }
 
+    public void clearCache(Player player) {
+        locationTimes.removeAll(player.getUniqueId());
+    }
+
 }

--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/PlayerList.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/PlayerList.java
@@ -400,6 +400,8 @@ public abstract class PlayerList {
         if (lastView != null && lastView.getHandle() instanceof ContainerPlayer && lastView.getPlayer() == bukkit) craftingManager.lastCraftView = null;
         // KigPaper end
 
+        Nacho.get().getLagCompensator().clearCache(bukkit);
+
         return playerQuitEvent.getQuitMessage(); // CraftBukkit
     }
 


### PR DESCRIPTION
# Description

Fixes an issue where a player's lag compensator cache would not be cleared after they disconnected.

# How has this been tested?

I haven't tested it but it's simple enough. 

# Checklist:

- [x] I have reviewed my code thoroughly.
- [ ] I have tested my code.
- [x] My changes generate no new warnings
