### PR TITLE
add disableDisconnectSpam config

### DIFF
--- a/NachoSpigot-Server/src/main/java/me/elier/nachospigot/config/NachoConfig.java
+++ b/NachoSpigot-Server/src/main/java/me/elier/nachospigot/config/NachoConfig.java
@@ -142,6 +142,7 @@ public class NachoConfig {
         c.addComment("settings.commands.permissions.plugins", "Enables a required permission to use /plugins");
         c.addComment("settings.commands.enable-help-command", "Toggles the /help command");
         c.addComment("settings.use-improved-hitreg", "Enables the usage of an improved hitreg based on lag compensation and small other details.");
+        c.addComment("settings.disable-disconnect-spam", "Disables that players can be kicked because of disconnect.spam.");
         NachoWorldConfig.loadComments();
     }
 
@@ -398,4 +399,9 @@ public class NachoConfig {
         enableImprovedHitReg = getBoolean("settings.use-improved-hitreg", false);
     }
 
+    public static boolean disableDisconnectSpam;
+
+    private static void disableDisconnectSpam() {
+        disableDisconnectSpam = getBoolean("settings.disable-disconnect-spam", false);
+    }
 }

--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/PlayerConnection.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/PlayerConnection.java
@@ -2127,25 +2127,27 @@ public class PlayerConnection implements PacketListenerPlayIn, IUpdatePlayerList
         }
         // CraftBukkit end
     }
-
+	
+	
     public void a(PacketPlayInTabComplete packetplayintabcomplete) {
-        PlayerConnectionUtils.ensureMainThread(packetplayintabcomplete, this, this.player.u());
-        // CraftBukkit start
-        if (chatSpamField.addAndGet(this, 10) > 500 && !this.minecraftServer.getPlayerList().isOp(this.player.getProfile())) {
-            this.disconnect("disconnect.spam");
-            return;
+        if (NachoConfig.disableDisconnectSpam == false) {
+            PlayerConnectionUtils.ensureMainThread(packetplayintabcomplete, this, this.player.u());
+            // CraftBukkit start
+            if (chatSpamField.addAndGet(this, 10) > 500 && !this.minecraftServer.getPlayerList().isOp(this.player.getProfile())) {
+                this.disconnect("disconnect.spam");
+                return;
+            }
+            // CraftBukkit end
+            ArrayList arraylist = Lists.newArrayList();
+            Iterator iterator = this.minecraftServer.tabCompleteCommand(this.player, packetplayintabcomplete.a(), packetplayintabcomplete.b()).iterator();
+
+            while (iterator.hasNext()) {
+                String s = (String) iterator.next();
+                arraylist.add(s);
+            }
+
+            this.player.playerConnection.sendPacket(new PacketPlayOutTabComplete((String[]) arraylist.toArray(new String[arraylist.size()])));
         }
-        // CraftBukkit end
-        ArrayList arraylist = Lists.newArrayList();
-        Iterator iterator = this.minecraftServer.tabCompleteCommand(this.player, packetplayintabcomplete.a(), packetplayintabcomplete.b()).iterator();
-
-        while (iterator.hasNext()) {
-            String s = (String) iterator.next();
-
-            arraylist.add(s);
-        }
-
-        this.player.playerConnection.sendPacket(new PacketPlayOutTabComplete((String[]) arraylist.toArray(new String[arraylist.size()])));
     }
 
     public void a(PacketPlayInSettings packetplayinsettings) {

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ See: [Contributors Page](https://github.com/CobbleSword/NachoSpigot/graphs/contr
 [Nacho-0033] Faster Operator search method
 [Nacho-0048] Don't allocate empty int arrays for particles
 [Nacho-0049] Option to disable Enchantment table ticking
+[Nacho-0052] Add config to disable disconnect.spam
 
 <--> by Sculas
 [Nacho-0034] Remove Java 8 message from TacoSpigot which made it so you couldn't run Java 8 or higher


### PR DESCRIPTION
# Description

Adds the option to disable that players can get kicked because of disconnect.spam. Mostly because of higher clients. The option doesnt include the line 1217 of exactly that file because I guess thats the real spam preventer and the other code which kicks for disconnect.spam in line 2132 which can be deactivated, is the detector of the chat how fast a user can type.

# How has this been tested?

i tested it whith typing and check if it triggers or not

# Checklist:

- [x] I have reviewed my code thoroughly.
- [x] I have tested my code.
- [x] My changes generate no new warnings
