### PR TITLE
fixes an usercache exception + getBlock npe

### DIFF
--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/UserCache.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/UserCache.java
@@ -197,9 +197,7 @@ public class UserCache {
                     this.a(usercache_usercacheentry.a(), usercache_usercacheentry.b());
                 }
             }
-        } catch (FileNotFoundException filenotfoundexception) {
-            ;
-        } catch (JsonParseException jsonparseexception) {
+        } catch (FileNotFoundException | JsonParseException ignored) {
             ;
         } catch (Exception ex) {
             // SportPaper - Catch all UserCache exceptions in one and always delete

--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/UserCache.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/UserCache.java
@@ -197,6 +197,10 @@ public class UserCache {
                     this.a(usercache_usercacheentry.a(), usercache_usercacheentry.b());
                 }
             }
+        } catch (FileNotFoundException filenotfoundexception) {
+            ;
+        } catch (JsonParseException jsonparseexception) {
+            ;
         } catch (Exception ex) {
             // SportPaper - Catch all UserCache exceptions in one and always delete
             JsonList.a.warn( "Usercache.json is corrupted or has bad formatting. Deleting it to prevent further issues." );

--- a/NachoSpigot-Server/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
+++ b/NachoSpigot-Server/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
@@ -150,7 +150,7 @@ public class CraftChunk implements Chunk {
             {
                 // This does a lookup in the block registry, but does not create any objects, so should be pretty efficient
                 IBlockData blockData = (IBlockData) net.minecraft.server.Block.d.a(blockIds[i]);
-                if(blockData.getBlock() == nmsBlock) {
+                if(blockData != null && blockData.getBlock() == nmsBlock) { // SportPaper - fix NPE
                     blocks.add(getBlock(i & 0xf, section.getYPosition() | (i >> 8), (i >> 4) & 0xf));
                 }
             }

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ See: [Contributors Page](https://github.com/CobbleSword/NachoSpigot/graphs/contr
 [SportPaper-0027] Fix head rotation packet spam
 [SportPaper-0043] Get blocks in Chunk API
 [SportPaper-0162] Fix PlayerInteractEvent not cancelling properly
+[SportPaper-0171] Fix NPE in CraftChunk#getBlocks
 [SportPaper-0197] Optimize head rotation patch
 [SportPaper-0201] Cache block break animation packet
 [SportPaper-0203] Fix Teleport Invisibility


### PR DESCRIPTION
# Description

fixes an unnecessary usercache error caused by FileNotFoundException or JsonParseException. The error appeared on file generation directly in the first log line. I added the two catches back to nullify them.
& adds https://github.com/Electroid/SportPaper/blob/master/patches/server/0171-Fix-NPE-in-CraftChunk-getBlocks.patch

# How has this been tested?

i checked the log

# Checklist:

- [x] I have reviewed my code thoroughly.
- [x] I have tested my code.
- [x] My changes generate no new warnings
