### PR TITLE
Fix for player#setFlying not changing the player's flying status

### DIFF
--- a/NachoSpigot-Server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+++ b/NachoSpigot-Server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
@@ -1277,13 +1277,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
 
     @Override
     public void setFlying(boolean value) {
-        boolean needsUpdate = getHandle().abilities.canFly != value; // PaperSpigot - Only refresh abilities if needed
         if (!getAllowFlight() && value) {
             throw new IllegalArgumentException("Cannot make player fly if getAllowFlight() is false");
         }
 
         getHandle().abilities.isFlying = value;
-        if (needsUpdate) getHandle().updateAbilities(); // PaperSpigot - Only refresh abilities if needed
+        getHandle().updateAbilities();
     }
 
     @Override


### PR DESCRIPTION
# Description

I have removed the check from setFlying to update the player's flying state. The current way prevents setting the player's flying state. IE: player.setFlying(true) would not make the player fly.

# How has this been tested?

I just made a simple plugin when joining the server to set setAllowFlight and setFlying to true.

# Checklist:

- [x] I have reviewed my code thoroughly.
- [x] I have tested my code.
- [x] My changes generate no new warnings
