### PR TITLE
bump netty to 4.1.75

### DIFF
--- a/NachoSpigot-Server/pom.xml
+++ b/NachoSpigot-Server/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
-            <version>4.1.68.Final</version>
+            <version>4.1.74.Final</version>
         </dependency>
 
         <dependency>

--- a/NachoSpigot-Server/pom.xml
+++ b/NachoSpigot-Server/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
-            <version>4.1.74.Final</version>
+            <version>4.1.75.Final</version>
         </dependency>
 
         <dependency>

--- a/NachoSpigot-Server/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+++ b/NachoSpigot-Server/src/main/java/org/bukkit/craftbukkit/CraftServer.java
@@ -297,10 +297,10 @@ public final class CraftServer implements Server {
                     // Nacho start - Add notice for older ProtocolLib versions
                     if(plugin.getDescription().getFullName().contains("ProtocolLib")) {
                         String[] tmp = plugin.getDescription().getVersion().split("\\.");
-                        if (Integer.parseInt(tmp[0]) <= 4 && Integer.parseInt(tmp[1]) <= 6) {
+                        if (Integer.parseInt(tmp[0]) <= 4 && Integer.parseInt(tmp[1]) <= 7) {
                             logger.warning(
-                                    "Please update to ProtocolLib version 4.7.0 or higher!\n" +
-                                            "In version 4.6.0 and lower, ProtocolLib does not work as expected due to a netty update.\n" +
+                                    "Please update to ProtocolLib version 4.8.0 or higher!\n" +
+                                            "In version 4.7.0 and lower, ProtocolLib does not work as expected due to a netty update.\n" +
                                             "So.. once again, please update!\n" +
                                             "You can download the latest version with this link: " +
                                             "https://github.com/dmulloy2/ProtocolLib/releases/latest\n" +


### PR DESCRIPTION
# Description

Bumped the netty version to latest (4.7.0) & adjust the protocollib check.

# Additional Comments

Merge this PR if you think its ready to move on. The switch to protocollib 4.7.0 to 4.8.0 doesnt need that much time and doesnt change things so everybody can simply upgrade.

# Checklist:

- [x] I have reviewed my code thoroughly.
- [x] I have tested my code.
- [x] My changes generate no new warnings
