### PR TITLE
Disable Nether Roof Interaction

### DIFF
--- a/NachoSpigot-Server/src/main/java/me/elier/nachospigot/config/NachoConfig.java
+++ b/NachoSpigot-Server/src/main/java/me/elier/nachospigot/config/NachoConfig.java
@@ -143,7 +143,7 @@ public class NachoConfig {
         c.addComment("settings.commands.enable-help-command", "Toggles the /help command");
         c.addComment("settings.use-improved-hitreg", "Enables the usage of an improved hitreg based on lag compensation and small other details.");
         c.addComment("settings.disable-disconnect-spam", "Disables that players can be kicked because of disconnect.spam.");
-        c.addComment("settings.disable-nether-roof-destroying", "Disables destorying the nether roof.");
+        c.addComment("settings.enable-nether-roof-destroying", "Enables a bigger protection for the nether roof.");
         NachoWorldConfig.loadComments();
     }
 
@@ -406,9 +406,9 @@ public class NachoConfig {
         disableDisconnectSpam = getBoolean("settings.disable-disconnect-spam", false);
     }
 
-    public static boolean disableNetherroofDestroying;
+    public static boolean enableNetherroofDestroying;
 
-    private static void disableNetherroofDestroying() {
-        disableNetherroofDestroying = getBoolean("settings.disable-nether-roof-destroying", false);
+    private static void enableNetherroofDestroying() {
+        enableNetherroofDestroying = getBoolean("settings.enable-nether-roof-destroying", false);
     }
 }

--- a/NachoSpigot-Server/src/main/java/me/elier/nachospigot/config/NachoConfig.java
+++ b/NachoSpigot-Server/src/main/java/me/elier/nachospigot/config/NachoConfig.java
@@ -143,7 +143,7 @@ public class NachoConfig {
         c.addComment("settings.commands.enable-help-command", "Toggles the /help command");
         c.addComment("settings.use-improved-hitreg", "Enables the usage of an improved hitreg based on lag compensation and small other details.");
         c.addComment("settings.disable-disconnect-spam", "Disables that players can be kicked because of disconnect.spam.");
-        c.addComment("settings.enable-nether-roof-destroying", "Enables a bigger protection for the nether roof.");
+        c.addComment("settings.disable-nether-roof-interaction", "Disables the interaction with the nether roof.");
         NachoWorldConfig.loadComments();
     }
 
@@ -406,9 +406,9 @@ public class NachoConfig {
         disableDisconnectSpam = getBoolean("settings.disable-disconnect-spam", false);
     }
 
-    public static boolean enableNetherroofDestroying;
+    public static boolean disableNetherroofInteraction;
 
-    private static void enableNetherroofDestroying() {
-        enableNetherroofDestroying = getBoolean("settings.enable-nether-roof-destroying", false);
+    private static void disableNetherroofInteraction() {
+        disableNetherroofInteraction = getBoolean("settings.disable-nether-roof-interaction", false);
     }
 }

--- a/NachoSpigot-Server/src/main/java/me/elier/nachospigot/config/NachoConfig.java
+++ b/NachoSpigot-Server/src/main/java/me/elier/nachospigot/config/NachoConfig.java
@@ -143,6 +143,7 @@ public class NachoConfig {
         c.addComment("settings.commands.enable-help-command", "Toggles the /help command");
         c.addComment("settings.use-improved-hitreg", "Enables the usage of an improved hitreg based on lag compensation and small other details.");
         c.addComment("settings.disable-disconnect-spam", "Disables that players can be kicked because of disconnect.spam.");
+        c.addComment("settings.disable-nether-roof-destroying", "Disables destorying the nether roof.");
         NachoWorldConfig.loadComments();
     }
 
@@ -403,5 +404,11 @@ public class NachoConfig {
 
     private static void disableDisconnectSpam() {
         disableDisconnectSpam = getBoolean("settings.disable-disconnect-spam", false);
+    }
+
+    public static boolean disableNetherroofDestroying;
+
+    private static void disableNetherroofDestroying() {
+        disableNetherroofDestroying = getBoolean("settings.disable-nether-roof-destroying", false);
     }
 }

--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/ItemStack.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/ItemStack.java
@@ -157,7 +157,7 @@ public final class ItemStack {
             List<BlockState> blocks = (List<BlockState>) world.capturedBlockStates.clone();
             world.capturedBlockStates.clear();
 
-            if (NachoConfig.disableNetherroofDestroying) {
+            if (NachoConfig.enableNetherroofDestroying) {
                 // FlamePaper start - Disable Nether Roof Interaction
                 if (world.getWorld().getEnvironment() == org.bukkit.World.Environment.NETHER) {
                     for (BlockState block : blocks) {

--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/ItemStack.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/ItemStack.java
@@ -157,7 +157,7 @@ public final class ItemStack {
             List<BlockState> blocks = (List<BlockState>) world.capturedBlockStates.clone();
             world.capturedBlockStates.clear();
 
-            if (NachoConfig.enableNetherroofDestroying) {
+            if (NachoConfig.disableNetherroofInteraction) {
                 // FlamePaper start - Disable Nether Roof Interaction
                 if (world.getWorld().getEnvironment() == org.bukkit.World.Environment.NETHER) {
                     for (BlockState block : blocks) {

--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/ItemStack.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/ItemStack.java
@@ -9,6 +9,7 @@ import java.util.Random;
 import java.util.List;
 import java.util.Map;
 
+import me.elier.nachospigot.config.NachoConfig;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.TreeType;
@@ -155,6 +156,20 @@ public final class ItemStack {
             org.bukkit.event.block.BlockPlaceEvent placeEvent = null;
             List<BlockState> blocks = (List<BlockState>) world.capturedBlockStates.clone();
             world.capturedBlockStates.clear();
+
+            if (NachoConfig.disableNetherroofDestroying) {
+                // FlamePaper start - Disable Nether Roof Interaction
+                if (world.getWorld().getEnvironment() == org.bukkit.World.Environment.NETHER) {
+                    for (BlockState block : blocks) {
+                        if (block.getY() >= 127) {
+                            entityhuman.getBukkitEntity().sendMessage(org.bukkit.ChatColor.translateAlternateColorCodes('&', "&cCan't build on nether roof"));
+                            return false;
+                        }
+                    }
+                }
+                // FlamePaper end - Disable Nether Roof Interaction
+            }
+
             if (blocks.size() > 1) {
                 placeEvent = org.bukkit.craftbukkit.event.CraftEventFactory.callBlockMultiPlaceEvent(world, entityhuman, blocks, blockposition.getX(), blockposition.getY(), blockposition.getZ());
             } else if (blocks.size() == 1) {

--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/PlayerInteractManager.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/PlayerInteractManager.java
@@ -300,7 +300,7 @@ public class PlayerInteractManager {
                 return false;
             }
 
-            if (NachoConfig.disableNetherroofDestroying) {
+            if (NachoConfig.enableNetherroofDestroying) {
                 // FlamePaper start - Disable Nether Roof Interaction
                 if (world.getWorld().getEnvironment() == org.bukkit.World.Environment.NETHER && blockposition.getY() >= 127) {
                     this.player.getBukkitEntity().sendMessage(org.bukkit.ChatColor.translateAlternateColorCodes('&', "&cCan't build on nether roof"));

--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/PlayerInteractManager.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/PlayerInteractManager.java
@@ -300,7 +300,7 @@ public class PlayerInteractManager {
                 return false;
             }
 
-            if (NachoConfig.enableNetherroofDestroying) {
+            if (NachoConfig.disableNetherroofInteraction) {
                 // FlamePaper start - Disable Nether Roof Interaction
                 if (world.getWorld().getEnvironment() == org.bukkit.World.Environment.NETHER && blockposition.getY() >= 127) {
                     this.player.getBukkitEntity().sendMessage(org.bukkit.ChatColor.translateAlternateColorCodes('&', "&cCan't build on nether roof"));

--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/PlayerInteractManager.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/PlayerInteractManager.java
@@ -1,6 +1,7 @@
 package net.minecraft.server;
 
 // CraftBukkit start
+import me.elier.nachospigot.config.NachoConfig;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.craftbukkit.event.CraftEventFactory;
 import org.bukkit.event.Event;
@@ -298,6 +299,17 @@ public class PlayerInteractManager {
                 }
                 return false;
             }
+
+            if (NachoConfig.disableNetherroofDestroying) {
+                // FlamePaper start - Disable Nether Roof Interaction
+                if (world.getWorld().getEnvironment() == org.bukkit.World.Environment.NETHER && blockposition.getY() >= 127) {
+                    this.player.getBukkitEntity().sendMessage(org.bukkit.ChatColor.translateAlternateColorCodes('&', "&cCan't build on nether roof"));
+                    ((EntityPlayer) this.player).playerConnection.sendPacket(new PacketPlayOutBlockChange(this.world, blockposition));
+                    return false;
+                }
+                // FlamePaper end - Disable Nether Roof Interaction
+            }
+
         }
         if (false && this.gamemode.d() && this.player.bA() != null && this.player.bA().getItem() instanceof ItemSword) {
             return false;

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ See: [Contributors Page](https://github.com/CobbleSword/NachoSpigot/graphs/contr
 [FlamePaper-0113] Remove unused code from beacons
 [FlamePaper-0115] Patch Book Exploits
 [FlamePaper-0117] Pearl through blocks
+[FlamePaper-0025] Disable Nether Roof Interaction
 
 [MineTick-0006] Fix Occasional Client Side Unloading of Chunk 0 0
 [MineTick-0011] Optimize Idle Furnaces


### PR DESCRIPTION
I cant break the roof in creative or like that, seems robust, but i can place but not break on top of it and the message appears, yeah because its coded like it should do that. cause of my other PRs, the readme order will change anyways so i pasted it just on the bottom of the flamepaper patches

# Checklist:

- [x] I have reviewed my code thoroughly.
- [x] I have tested my code.
- [x] My changes generate no new warnings
