### PR TITLE
Add better PlayerVelocityEvent support

### DIFF
--- a/NachoSpigot-API/src/main/java/org/bukkit/entity/HumanEntity.java
+++ b/NachoSpigot-API/src/main/java/org/bukkit/entity/HumanEntity.java
@@ -174,4 +174,26 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, Permissible, Inv
      * @return Experience required to level up
      */
     public int getExpToLevel();
+
+    // Nacho start
+    /**
+     *
+     * @return The player's current amount of absorption hearts.
+     */
+    float getAbsorption();
+
+    /**
+     * Sets the player's current amount of absorption hearts.
+     * @param amount Amount of absorption the player should have.
+     */
+    void setAbsorption(float amount);
+
+    /**
+     * Adds the specified amount of absorption to the player.
+     * @param amount Amount of absorption to add.
+     */
+    default void addAbsorption(float amount){
+        setAbsorption(getAbsorption() + amount);
+    }
+    // Nacho end
 }

--- a/NachoSpigot-API/src/main/java/org/bukkit/entity/LivingEntity.java
+++ b/NachoSpigot-API/src/main/java/org/bukkit/entity/LivingEntity.java
@@ -9,10 +9,13 @@ import dev.cobblesword.nachospigot.knockback.KnockbackProfile;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
+import org.bukkit.event.entity.EntityRegainHealthEvent;
 import org.bukkit.inventory.EntityEquipment;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.projectiles.ProjectileSource;
+import org.bukkit.event.entity.EntityRegainHealthEvent;
+import org.bukkit.event.entity.EntityRegainHealthEvent.RegainReason;
 
 /**
  * Represents a living entity, such as a monster or player
@@ -429,5 +432,18 @@ public interface LivingEntity extends Entity, Damageable, ProjectileSource {
     public boolean shouldPullWhileLeashed();
 
     public void setPullWhileLeashed(boolean pullWhileLeashed);
+
+    /**
+     * Heals the entity for the specified amount, with {@link RegainReason#CUSTOM}. Only functions if {@code amount} is greater than 0 and less than the entity's max health. Will call {@link EntityRegainHealthEvent}.
+     * @param amount Amount to heal the entity.
+     */
+    public void heal(float amount);
+
+    /**
+     * Heals the entity for the specified amount, with the specified reason. Only functions if {@code amount} is greater than 0 and less than the entity's max health. Will call {@link EntityRegainHealthEvent}.
+     * @param amount Amount to heal the entity.
+     * @param reason Regain reason, included in event call.
+     */
+    public void heal(float amount, EntityRegainHealthEvent.RegainReason reason);
     // Nacho end
 }

--- a/NachoSpigot-API/src/main/java/org/bukkit/entity/LivingEntity.java
+++ b/NachoSpigot-API/src/main/java/org/bukkit/entity/LivingEntity.java
@@ -434,13 +434,13 @@ public interface LivingEntity extends Entity, Damageable, ProjectileSource {
     public void setPullWhileLeashed(boolean pullWhileLeashed);
 
     /**
-     * Heals the entity for the specified amount, with {@link RegainReason#CUSTOM}. Only functions if {@code amount} is greater than 0 and less than the entity's max health. Will call {@link EntityRegainHealthEvent}.
+     * Heals the entity for the specified amount, with {@link RegainReason#CUSTOM}. If {@code amount} is less than 0, the code will not run. If, after event processing, the amount to heal will make the entity exceed their max health, then their health will be rounded to their max health. Will call {@link EntityRegainHealthEvent}.
      * @param amount Amount to heal the entity.
      */
     public void heal(float amount);
 
     /**
-     * Heals the entity for the specified amount, with the specified reason. Only functions if {@code amount} is greater than 0 and less than the entity's max health. Will call {@link EntityRegainHealthEvent}.
+     * Heals the entity for the specified amount, with the specified reason. If {@code amount} is less than 0, the code will not run. If, after event processing, the amount to heal will make the entity exceed their max health, then their health will be rounded to their max health. Will call {@link EntityRegainHealthEvent}.
      * @param amount Amount to heal the entity.
      * @param reason Regain reason, included in event call.
      */

--- a/NachoSpigot-API/src/main/java/org/bukkit/entity/Player.java
+++ b/NachoSpigot-API/src/main/java/org/bukkit/entity/Player.java
@@ -1410,6 +1410,7 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
     Spigot spigot();
     // Spigot end
 
+    // Nacho start
     class NachoPlayer {
         /**
          * Sends an actionbar message to the player
@@ -1428,6 +1429,25 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
     }
 
     NachoPlayer nacho();
+
+    /**
+     *
+     * @return The player's current amount of absorption hearts.
+     */
+    float getAbsorption();
+
+    /**
+     * Sets the player's current amount of absorption hearts.
+     * @param amount Amount of absorption the player should have.
+     */
+    void setAbsorption(float amount);
+
+    /**
+     * Adds the specified amount of absorption to the player.
+     * @param amount Amount of absorption to add.
+     */
+    void addAbsorption(float amount);
+    // Nacho end
 
     class Unsafe {
         /**

--- a/NachoSpigot-API/src/main/java/org/bukkit/entity/Player.java
+++ b/NachoSpigot-API/src/main/java/org/bukkit/entity/Player.java
@@ -1332,7 +1332,7 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
         }
 
         /**
-         * Gets all players hidden with {@link hidePlayer(org.bukkit.entity.Player)}.
+         * Gets all players hidden with {@link Player#hidePlayer(Player)}.
          *
          * @return a Set with all hidden players
          */
@@ -1429,24 +1429,6 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
     }
 
     NachoPlayer nacho();
-
-    /**
-     *
-     * @return The player's current amount of absorption hearts.
-     */
-    float getAbsorption();
-
-    /**
-     * Sets the player's current amount of absorption hearts.
-     * @param amount Amount of absorption the player should have.
-     */
-    void setAbsorption(float amount);
-
-    /**
-     * Adds the specified amount of absorption to the player.
-     * @param amount Amount of absorption to add.
-     */
-    void addAbsorption(float amount);
     // Nacho end
 
     class Unsafe {

--- a/NachoSpigot-API/src/main/java/org/bukkit/event/player/PlayerVelocityEvent.java
+++ b/NachoSpigot-API/src/main/java/org/bukkit/event/player/PlayerVelocityEvent.java
@@ -12,10 +12,16 @@ public class PlayerVelocityEvent extends PlayerEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
     private boolean cancel = false;
     private Vector velocity;
+    private final boolean fromAttack;
 
-    public PlayerVelocityEvent(final Player player, final Vector velocity) {
+    public PlayerVelocityEvent(final Player player, final Vector velocity, final boolean fromPlayerBeingAttacked) {
         super(player);
         this.velocity = velocity;
+        this.fromAttack = fromPlayerBeingAttacked;
+    }
+
+    public PlayerVelocityEvent(final Player player, final Vector velocity) {
+        this(player, velocity, false);
     }
 
     public boolean isCancelled() {
@@ -51,5 +57,13 @@ public class PlayerVelocityEvent extends PlayerEvent implements Cancellable {
 
     public static HandlerList getHandlerList() {
         return handlers;
+    }
+
+    /**
+     *
+     * @return Whether this velocity change was triggered due to the player being attacked by another player.
+     */
+    public boolean fromPlayerBeingAttacked(){
+        return fromAttack;
     }
 }

--- a/NachoSpigot-API/src/main/java/org/bukkit/event/player/PlayerVelocityEvent.java
+++ b/NachoSpigot-API/src/main/java/org/bukkit/event/player/PlayerVelocityEvent.java
@@ -63,7 +63,7 @@ public class PlayerVelocityEvent extends PlayerEvent implements Cancellable {
      *
      * @return Whether this velocity change was triggered due to the player being attacked by another player.
      */
-    public boolean fromPlayerBeingAttacked(){
+    public boolean fromAttack(){
         return fromAttack;
     }
 }

--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/EntityHuman.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/EntityHuman.java
@@ -1025,7 +1025,7 @@ public abstract class EntityHuman extends EntityLiving {
                         if (entity instanceof EntityPlayer && entity.velocityChanged) {
                             Player player = (Player) entity.getBukkitEntity();
                             final Vector velocity = new Vector(entity.motX, entity.motY, entity.motZ);
-                            PlayerVelocityEvent event = new PlayerVelocityEvent(player, velocity);
+                            PlayerVelocityEvent event = new PlayerVelocityEvent(player, velocity, true);
                             world.getServer().getPluginManager().callEvent(event);
 
                             if (!event.isCancelled()) {

--- a/NachoSpigot-Server/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
+++ b/NachoSpigot-Server/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
@@ -362,4 +362,12 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
     public int getExpToLevel() {
         return getHandle().getExpToLevel();
     }
+
+    public float getAbsorption(){
+        return getHandle().getAbsorptionHearts();
+    }
+
+    public void setAbsorption(float amount){
+        getHandle().setAbsorptionHearts(amount);
+    }
 }

--- a/NachoSpigot-Server/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
+++ b/NachoSpigot-Server/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
@@ -54,6 +54,7 @@ import org.bukkit.entity.Snowball;
 import org.bukkit.entity.ThrownExpBottle;
 import org.bukkit.entity.ThrownPotion;
 import org.bukkit.entity.WitherSkull;
+import org.bukkit.event.entity.EntityRegainHealthEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.inventory.EntityEquipment;
 import org.bukkit.inventory.ItemStack;
@@ -540,6 +541,17 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
             ((EntityInsentient) getHandle()).setPullWhileLeashed(pullWhileLeashed);
     }
     // TacoSpigot end
+
+    // Nacho start
+    public void heal(float amount){
+        if(getHealth() + amount <= getMaxHealth()) getHandle().heal(amount);
+    }
+
+    public void heal(float amount, EntityRegainHealthEvent.RegainReason reason){
+        if(getHealth() + amount <= getMaxHealth())
+            getHandle().heal(amount, reason);
+    }
+    // Nacho end
 
     @Override
     public KnockbackProfile getKnockbackProfile() {

--- a/NachoSpigot-Server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+++ b/NachoSpigot-Server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
@@ -1700,18 +1700,6 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
     public NachoPlayer nacho() {
         return nacho;
     }
-
-    public float getAbsorption(){
-        return getHandle().getAbsorptionHearts();
-    }
-
-    public void setAbsorption(float amount){
-        getHandle().setAbsorptionHearts(amount);
-    }
-
-    public void addAbsorption(float amount){
-        setAbsorption(getAbsorption() + amount);
-    }
     // Nacho end
 
     private final Unsafe unsafe = new Unsafe() {

--- a/NachoSpigot-Server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+++ b/NachoSpigot-Server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
@@ -1669,6 +1669,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
         return spigot;
     }
 
+    // Nacho start
     private final NachoPlayer nacho = new NachoPlayer() {
         @Override
         public void sendActionBar(String message) {
@@ -1699,6 +1700,19 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
     public NachoPlayer nacho() {
         return nacho;
     }
+
+    public float getAbsorption(){
+        return getHandle().getAbsorptionHearts();
+    }
+
+    public void setAbsorption(float amount){
+        getHandle().setAbsorptionHearts(amount);
+    }
+
+    public void addAbsorption(float amount){
+        setAbsorption(getAbsorption() + amount);
+    }
+    // Nacho end
 
     private final Unsafe unsafe = new Unsafe() {
         @Override


### PR DESCRIPTION
My PRQ allows API users to check if a PlayerVelocityEvent was caused by the player being attacked by another player. This will pave the way for better and more direct knockback manipulation.

Please provide a detailed description of the changes you have made.

Adds a final boolean variable in PlayerVelocityEvent that defines if the event was caused by a player being attacked by another player.

# How has this been tested?
As I simply just added a variable inside the PlayerVelocityEvent class that overflows with the default constructor, I have not tested this change.
# Checklist:

- [X] I have reviewed my code thoroughly.
- [ ] I have tested my code.
- [X] My changes generate no new warnings
