### PR TITLE
Added better PlayerVelocityEvent support

### DIFF
--- a/NachoSpigot-API/src/main/java/org/bukkit/event/player/PlayerVelocityEvent.java
+++ b/NachoSpigot-API/src/main/java/org/bukkit/event/player/PlayerVelocityEvent.java
@@ -12,10 +12,16 @@ public class PlayerVelocityEvent extends PlayerEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
     private boolean cancel = false;
     private Vector velocity;
+    private final boolean fromAttack;
 
-    public PlayerVelocityEvent(final Player player, final Vector velocity) {
+    public PlayerVelocityEvent(final Player player, final Vector velocity, final boolean fromPlayerBeingAttacked) {
         super(player);
         this.velocity = velocity;
+        this.fromAttack = fromPlayerBeingAttacked;
+    }
+
+    public PlayerVelocityEvent(final Player player, final Vector velocity) {
+        this(player, velocity, false);
     }
 
     public boolean isCancelled() {
@@ -51,5 +57,13 @@ public class PlayerVelocityEvent extends PlayerEvent implements Cancellable {
 
     public static HandlerList getHandlerList() {
         return handlers;
+    }
+
+    /**
+     *
+     * @return Whether this velocity change was triggered due to the player being attacked by another player.
+     */
+    public boolean fromPlayerBeingAttacked(){
+        return fromAttack;
     }
 }

--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/EntityHuman.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/EntityHuman.java
@@ -1025,7 +1025,7 @@ public abstract class EntityHuman extends EntityLiving {
                         if (entity instanceof EntityPlayer && entity.velocityChanged) {
                             Player player = (Player) entity.getBukkitEntity();
                             final Vector velocity = new Vector(entity.motX, entity.motY, entity.motZ);
-                            PlayerVelocityEvent event = new PlayerVelocityEvent(player, velocity);
+                            PlayerVelocityEvent event = new PlayerVelocityEvent(player, velocity, true);
                             world.getServer().getPluginManager().callEvent(event);
 
                             if (!event.isCancelled()) {


### PR DESCRIPTION
- PlayerVelocityEvent now details if the event was fired from player attack knockback

Fixes/Adds # (issue)
Adds a final boolean in PlayerVelocityEvent that determines if the event was from the player being attacked
# How has this been tested?
It has not. Sorry! (I didn't think it was necessary as I was just adding a final variable that overloaded with the default constructor)

# Additional Comments

This should allow for better knockback modification by plugins.

# Checklist:

- [X ] I have reviewed my code thoroughly.
- [ ] I have tested my code.
- [X] My changes generate no new warnings
