### PR TITLE
Don't allow plugins to set problematic velocity vectors

### DIFF
--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/EntityHuman.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/EntityHuman.java
@@ -1030,7 +1030,13 @@ public abstract class EntityHuman extends EntityLiving {
 
                             if (!event.isCancelled()) {
                                 if (!velocity.equals(event.getVelocity())) {
-                                    player.setVelocity(event.getVelocity());
+                                    // Nacho start - don't allow plugins to set problematic velocity vectors
+                                    org.bukkit.util.Vector newVelocity = event.getVelocity();
+                                    if(newVelocity.getX() != newVelocity.getX()) newVelocity.setX(0);
+                                    if(newVelocity.getY() != newVelocity.getY()) newVelocity.setY(0);
+                                    if(newVelocity.getZ() != newVelocity.getZ()) newVelocity.setZ(0);
+                                    // Nacho end
+                                    player.setVelocity(newVelocity);
                                 }
                                 ((EntityPlayer) entity).playerConnection.sendPacket(new PacketPlayOutEntityVelocity(entity));
                                 entity.velocityChanged = false;

--- a/NachoSpigot-Server/src/main/java/net/minecraft/server/EntityTrackerEntry.java
+++ b/NachoSpigot-Server/src/main/java/net/minecraft/server/EntityTrackerEntry.java
@@ -263,7 +263,13 @@ public class EntityTrackerEntry {
                 if (event.isCancelled()) {
                     cancelled = true;
                 } else if (!velocity.equals(event.getVelocity())) {
-                    player.setVelocity(event.getVelocity());
+                    // Nacho start - don't allow plugins to set problematic velocity vectors
+                    org.bukkit.util.Vector newVelocity = event.getVelocity();
+                    if(newVelocity.getX() != newVelocity.getX()) newVelocity.setX(0);
+                    if(newVelocity.getY() != newVelocity.getY()) newVelocity.setY(0);
+                    if(newVelocity.getZ() != newVelocity.getZ()) newVelocity.setZ(0);
+                    // Nacho end
+                    player.setVelocity(newVelocity);
                 }
             }
 

--- a/NachoSpigot-Server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
+++ b/NachoSpigot-Server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
@@ -213,6 +213,10 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
             }
         }
         // Paper end
+        
+        // Paper start - don't allow plugins to set problematic velocity vectors
+        Preconditions.checkArgument(vel.getX() == vel.getX() && vel.getY() == vel.getY() && vel.getZ() == vel.getZ(), "Illegal velocity vector: " + vel);
+        // Paper end
 
         entity.motX = vel.getX();
         entity.motY = vel.getY();

--- a/NachoSpigot-Server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
+++ b/NachoSpigot-Server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
@@ -214,9 +214,9 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
         }
         // Paper end
         
-        // Paper start - don't allow plugins to set problematic velocity vectors
+        // Nacho start - don't allow plugins to set problematic velocity vectors
         Preconditions.checkArgument(vel.getX() == vel.getX() && vel.getY() == vel.getY() && vel.getZ() == vel.getZ(), "Illegal velocity vector: " + vel);
-        // Paper end
+        // Nacho end
 
         entity.motX = vel.getX();
         entity.motY = vel.getY();


### PR DESCRIPTION
# Description

Currently plugins can use the api to set a players velocity to illegal values like `NaN` which causes the server to freeze under some circumstances. 

In `Entity.java:541` we can find this loop:
````java
                for (d9 = 0.05D; d0 != 0.0D && this.world.getCubes(this, this.getBoundingBox().c(d0, -1.0D, 0.0D)).isEmpty(); d6 = d0) {
                    if (d0 < d9 && d0 >= -d9) {
                        d0 = 0.0D;
                    } else if (d0 > 0.0D) {
                        d0 -= d9;
                    } else {
                        d0 += d9;
                    }
                }
````

The check `d0 != 0.0D ` is important here: `d0` will be initialized with the entities `motionX`.
If `motionX` (or in the following loops `motionY`, `motionZ`) is `NaN` , this check is always `false` since `NaN += x = NaN` resulting in an endless loop and the server to freeze/crash.

The fix implemented in this PR is to disallow plugins to set any `NaN` values through the `setVelocity(...)` api.
Another way of fixing this would be to check if `d0` is `NaN` and overriding it with `0`. But i think it's better to not allow setting `NaN` in the first place at the api layer.
Fixes #409 

# How has this been tested?

On a production server with 20-30 players for 24 hours without any crashes.

# Checklist:

- [X] I have reviewed my code thoroughly.
- [X] I have tested my code.
- [X] My changes generate no new warnings
